### PR TITLE
Remove setting of PT_HPU_LAZY_MODE=2 in training_args.py

### DIFF
--- a/optimum/habana/transformers/training_args.py
+++ b/optimum/habana/transformers/training_args.py
@@ -651,12 +651,9 @@ class GaudiTrainingArguments(TrainingArguments):
 
             if self.use_lazy_mode:
                 logger.info("Enabled lazy mode.")
-            # TODO: remove the block below when upgrade to SynapseAI 1.13 is done
-            # as eager mode will not be available anymore
             elif not self.torch_compile:
                 if os.getenv("PT_HPU_LAZY_MODE", "1") != "0":
-                    os.environ["PT_HPU_LAZY_MODE"] = "2"
-                logger.info("Enabled eager mode because use_lazy_mode=False.")
+                    assert False, "Lazy mode or compile mode not enabled => eager mode should be enabled using PT_HPU_LAZY_MODE=0"
 
             if self.deepspeed:
                 # Need to do similar for Accelerator init


### PR DESCRIPTION
Cleanup code in training_args.py to remove setting of PT_HPU_LAZY_MODE=2 (this is not supported SynapseAI release 1.13.0 onwards).

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
