### PR TITLE
enable falcon-180b inference

### DIFF
--- a/optimum/habana/checkpoint_utils.py
+++ b/optimum/habana/checkpoint_utils.py
@@ -65,8 +65,8 @@ def get_checkpoint_files(model_name_or_path, local_rank, token=None):
     safe_index_present = os.path.isfile(safe_index_file)
 
     if not index_present and not safe_index_present:
-        filenames = (WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_INDEX_NAME)
-        raise ValueError(f"Can't find a checkpoint index ({' or '.join(filenames)}) in {folder}.")
+        filenames = (transformers.modeling_utils.WEIGHTS_INDEX_NAME, transformers.modeling_utils.SAFE_WEIGHTS_INDEX_NAME)
+        raise ValueError(f"Can't find a checkpoint index ({' or '.join(filenames)}) in {cached_repo_dir}.")
 
     load_index = safe_index_file if safe_index_present else index_file
 

--- a/optimum/habana/checkpoint_utils.py
+++ b/optimum/habana/checkpoint_utils.py
@@ -56,9 +56,12 @@ def get_checkpoint_files(model_name_or_path, local_rank, token=None):
     """
     cached_repo_dir = get_repo_root(model_name_or_path, local_rank=local_rank, token=token)
 
-    # Extensions: .bin | .pt
+    # Extensions: .bin | .pt | .safetensors
     # Creates a list of paths from all downloaded files in cache dir
-    file_list = [str(entry) for entry in Path(cached_repo_dir).rglob("*.[bp][it][n]") if entry.is_file()]
+    exts = [".bin", ".pt", ".safetensors"]
+    file_list = [
+        str(entry) for entry in Path(cached_repo_dir).rglob("*") if (entry.is_file() and entry.suffix in exts)
+    ]
     return file_list
 
 

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -542,6 +542,9 @@ class GaudiGenerationMixin(GenerationMixin):
             generation_config.ignore_eos = kwargs.get("ignore_eos", lazy_mode)
         generation_config.validate()
         model_kwargs = generation_config.update(**kwargs)  # All unused kwargs must be model kwargs
+        if self.config.model_type == "falcon" and "token_type_ids" in kwargs.keys():
+            for key in ["token_type_ids"]:
+                model_kwargs.pop(key, None)
         self._validate_model_kwargs(model_kwargs.copy())
         # 2. Set generation parameters if not already defined
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()


### PR DESCRIPTION
1 The current code can load only .bin or .pt whereas Falcon-180B ckpt files are in .safetensors format. This change enabled loading ckpt files in .safetensor format
2 The ValueError "The following `model_kwargs` are not used by the model: ['token_type_ids'] )" is addressed by introducing a workaround that removes ‘token_type_ids’ from the model_kwargs.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
