### PR TITLE
Disable SDPA attention layer for Mistral and gpt_bigcode

### DIFF
--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -172,7 +172,8 @@ python ../gaudi_spawn.py --use_deepspeed --world_size 8 run_generation.py \
 > --use_hpu_graphs \
 > --use_kv_cache \
 > --max_new_tokens 100 \
-> --bf16
+> --bf16 \
+> --disable_sdpa_attention
 > ```
 
 

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -173,7 +173,7 @@ python ../gaudi_spawn.py --use_deepspeed --world_size 8 run_generation.py \
 > --use_kv_cache \
 > --max_new_tokens 100 \
 > --bf16 \
-> --disable_sdpa_attention
+> --attn_implementation eager
 > ```
 
 

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -259,6 +259,12 @@ def setup_parser(parser):
         action="store_true",
         help="Whether to enable device map auto. In case no space left on cpu, weights will be offloaded to disk.",
     )
+    parser.add_argument(
+        "--disable_sdpa_attention",
+        action="store_true",
+        help="Whether to disable SDPA Attention.",
+    )
+
     args = parser.parse_args()
 
     if args.torch_compile:

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -260,9 +260,10 @@ def setup_parser(parser):
         help="Whether to enable device map auto. In case no space left on cpu, weights will be offloaded to disk.",
     )
     parser.add_argument(
-        "--disable_sdpa_attention",
-        action="store_true",
-        help="Whether to disable SDPA Attention.",
+        "--attn_implementation",
+        type=str,
+        help={"Choose whether to override framework configuration to use torch scale dot product attention or not. Note this is not same as HPU FusedSDPA."},
+        choices= ["eager", "sdpa"],
     )
 
     args = parser.parse_args()

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -379,6 +379,9 @@ def initialize_model(args, logger):
         model_kwargs["device_map"] = "auto"
         model_kwargs["offload_folder"] = "/tmp/offload_folder/"
 
+    if args.disable_sdpa_attention:
+        model_kwargs["attn_implementation"] = 'eager'
+
     model = (
         setup_model(args, model_dtype, model_kwargs, logger)
         if not use_deepspeed

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -379,8 +379,8 @@ def initialize_model(args, logger):
         model_kwargs["device_map"] = "auto"
         model_kwargs["offload_folder"] = "/tmp/offload_folder/"
 
-    if args.disable_sdpa_attention:
-        model_kwargs["attn_implementation"] = 'eager'
+    if args.attn_implementation:
+        model_kwargs["attn_implementation"] = args.attn_implementation
 
     model = (
         setup_model(args, model_dtype, model_kwargs, logger)

--- a/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/optimum/habana/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -363,7 +363,12 @@ class GaudiGPTBigCodeForCausalLM(GPTBigCodeForCausalLM):
     - add token_idx into model_inputs
     - when KV cache is enabled, slice next_input_ids from input_ids based on the token_idx
     - when KV cache is enabled, slice next_position_ids from position_ids based on the token_idx
+    - disable sdpa attention layer
     """
+    def __init__(self, config):
+        #Disable SDPA until it's supported in GPTBigCode for Gaudi
+        config._attn_implementation='eager'
+        super().__init__(config)
 
     def prepare_inputs_for_generation(
         self, input_ids, past_key_values=None, inputs_embeds=None, token_idx=None, **kwargs

--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -347,6 +347,11 @@ def gaudi_mistral_model_forward(
 
 
 class GaudiMistralForCausalLM(MistralForCausalLM):
+    def __init__(self, config):
+        #Disable SDPA until it's supported for Mistral model in Gaudi
+        config._attn_implementation='eager'
+        super().__init__(config)
+
     def forward(
         self,
         input_ids: torch.LongTensor = None,


### PR DESCRIPTION
# What does this PR do?
Currently mistral and bigcode-gpt model throw error due to SDPA attention layer is enabled by default from torch2.2+transformer 4.37.2. We are disabling it in the model file, so the model can fall back to the original attention layer.  

This code can be removed after both model add proper support for FusedSDPA attention layer.