### PR TITLE
add quantization config example including measure of output tensors

### DIFF
--- a/examples/text-generation/quantization_config/maxabs_measure_include_ouputs.json
+++ b/examples/text-generation/quantization_config/maxabs_measure_include_ouputs.json
@@ -1,0 +1,10 @@
+{
+    "method": "HOOKS",
+    "mode": "MEASURE",
+    "observer": "maxabs",
+    "measure_exclude": "NONE",
+    "allowlist": {"types": [], "names":  []},
+    "blocklist": {"types": [], "names":  []},
+    "dump_stats_path": "./hqt_output/measure",
+    "dump_stats_xlsx_path": "./hqt_output/measure/fp8stats.xlsx"
+}


### PR DESCRIPTION
by default the habana-quantization-toolkit exclude output tensor scale measurements for quantization
added a json config example of how to enable the measurements of the output tensors.