### PR TITLE
Added additional check to run with distributed enabled and  world_size=1 (#96)

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -696,7 +696,8 @@ class GaudiLlamaModel(LlamaModel):
             htcore.mark_step()
 
         for layer_idx, decoder_layer in enumerate(self.layers):
-            if lazy_mode and torch.distributed.is_initialized() == False:
+            if lazy_mode and use_flash_attention and \
+                (torch.distributed.is_initialized() is False or torch.distributed.get_world_size() == 1):
                 htcore.mark_step()
 
             if output_hidden_states:


### PR DESCRIPTION
    Added additional check to run with distributed enabled and  world_size=1 (#96)

    * Added additional check to run with distributed enabled and  world_size = 1
    * Reduce the number of graph splits to avoid memory allocation error  for 1x LLAMA1_7b_ft

