### PR TITLE
Remove deprecated AOT_HPU_TRAINING_BACKEND

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -157,7 +157,7 @@ def patch_scoped_linear_all_reduce(model):
 
 
 def get_torch_compiled_model(model):
-    model.model = torch.compile(model.model, backend="aot_hpu_inference_backend")
+    model.model = torch.compile(model.model, backend="hpu_backend")
     return model
 
 

--- a/optimum/habana/accelerate/utils/dataclasses.py
+++ b/optimum/habana/accelerate/utils/dataclasses.py
@@ -73,7 +73,6 @@ class GaudiDynamoBackend(str, BaseEnum):
         - **IPEX** -- Uses IPEX for inference on CPU. Inference only. [Read
           more](https://github.com/intel/intel-extension-for-pytorch).
         - **TVM** -- Uses Apach TVM for inference optimizations. [Read more](https://tvm.apache.org/)
-        - **AOT_HPU_TRAINING_BACKEND** -- Uses Habana Gaudi - depracated - will be removed.
         - **HPU_BACKEND** -- Uses Habana Gaudi.
 
     """
@@ -92,7 +91,6 @@ class GaudiDynamoBackend(str, BaseEnum):
     TENSORRT = "TENSORRT"
     IPEX = "IPEX"
     TVM = "TVM"
-    AOT_HPU_TRAINING_BACKEND = "AOT_HPU_TRAINING_BACKEND"
     HPU_BACKEND = "HPU_BACKEND"
 
 

--- a/tests/test_fsdp_examples.py
+++ b/tests/test_fsdp_examples.py
@@ -78,7 +78,7 @@ def _test_fsdp(
         f"--fsdp_config {path_to_example_dir / task / 'fsdp_config.json'}",
         f"--fsdp '{policy}'",
         "--do_eval",
-        "--torch_compile_backend aot_hpu_training_backend",
+        "--torch_compile_backend hpu_backend",
         "--torch_compile",
     ]
 


### PR DESCRIPTION
The new backend has been introduced to pytorch-integraton - HPU_BACKEND . The deprecated backend ( AOT_HPU_TRAINING_BACKEND ) shall no longer be available in optimum habana as it's going to be removed from pytorch-integration.