### PR TITLE
Fix get_dtype and convert_into_dtypes (#769)

### DIFF
--- a/optimum/habana/transformers/trainer_utils.py
+++ b/optimum/habana/transformers/trainer_utils.py
@@ -40,7 +40,7 @@ def get_dtype(logits: Union[torch.Tensor, Tuple[torch.Tensor]]) -> Union[str, Li
             logits_dtype = "float32"
         return logits_dtype
     elif isinstance(logits, tuple):
-        return [get_dtype(logits_tensor) for logits_tensor in logits]
+        return get_dtype(logits[0])
     elif isinstance(logits, dict):
         return {k: get_dtype(v) for k, v in logits.items()}
     else:
@@ -48,27 +48,27 @@ def get_dtype(logits: Union[torch.Tensor, Tuple[torch.Tensor]]) -> Union[str, Li
 
 
 def convert_into_dtypes(
-    preds: Union[np.ndarray, Tuple[np.ndarray]], dtypes: Union[str, List[str]]
+    preds: Union[np.ndarray, Tuple[np.ndarray]], dtype: str
 ) -> Union[np.ndarray, Tuple[np.ndarray]]:
     """
-    Convert preds into dtypes.
+    Convert preds into the target dtype.
 
     Args:
         preds (Union[np.ndarray, Tuple[np.ndarray]]): predictions to convert
-        dtypes (Union[str, List[str]]): dtypes used for the conversion
+        dtype (str): dtype used for the conversion
 
     Raises:
-        TypeError: only torch.Tensor and tuple are supported
+        TypeError: only np.ndarray and tuple are supported
 
     Returns:
         Union[np.ndarray, Tuple[np.ndarray]]: converted preds
     """
     if isinstance(preds, np.ndarray):
-        if preds.dtype == dtypes:
+        if preds.dtype == dtype:
             return preds
         else:
-            return preds.astype(dtypes)
+            return preds.astype(dtype)
     elif isinstance(preds, tuple):
-        return tuple(convert_into_dtypes(preds_tensor, dtypes[i]) for i, preds_tensor in enumerate(preds))
+        return tuple(convert_into_dtypes(preds_tensor, dtype) for preds_tensor in preds)
     else:
         raise TypeError(f"preds should be of type np.ndarray or tuple, got {type(preds)} which is not supported")


### PR DESCRIPTION
# What does this PR do?

This is the cherry-pick of the Optimum-habana commit https://github.com/huggingface/optimum-habana/pull/769. The fix consists in extracting the dtype of the first logit tensor and set it as the target dtype. We used to extract the dtypes of all logit tensors, leading to nested tuples that led to this issue. There is no reason for logits to have different dtypes, so we can simplify the dtype extraction logic.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (https://github.com/huggingface/optimum-habana/issues/754)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
