### PR TITLE
[SW-12028] - set ds config "reduce scatter" to false

### DIFF
--- a/examples/summarization/ds_flan_t5_z3_config_bf16.json
+++ b/examples/summarization/ds_flan_t5_z3_config_bf16.json
@@ -27,6 +27,7 @@
     "contiguous_gradients": true,
     "sub_group_size": 1e9,
     "reduce_bucket_size": 1666777,
+    "reduce_scatter" : false,
     "stage3_prefetch_bucket_size": "auto",
     "stage3_param_persistence_threshold": "auto",
     "stage3_max_live_parameters": 1e9,


### PR DESCRIPTION
# What does this PR do?
This PR changes the deepspeed config of summarization models to
run with "reduce_scatter" : false by default.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
FlanT5 performance issue where the 8x performance drops to 5% when ran with deepspeed.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
