### PR TITLE
Downgrade pytest in language modelling

### DIFF
--- a/examples/language-modeling/requirements.txt
+++ b/examples/language-modeling/requirements.txt
@@ -5,3 +5,4 @@ protobuf
 evaluate
 scikit-learn
 peft == 0.6.2
+pytest == 7.4.2


### PR DESCRIPTION
Fix pytest version in language modelling as a temporary measure untill TF 4.39.

(final fix: https://github.com/huggingface/transformers/pull/29154)
