### PR TITLE
Added Mistral fp8 support

### DIFF
--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -239,7 +239,7 @@ While `--bucket_size` works for any model without model file changes, an even mo
 
 ### Running with FP8
 
-Llama2-70b, Llama2-7b,  Mixtral-8x7B, Falcon-7B, Falcon-40B, and Falcon-180B in FP8 are enabled using the Quantization Toolkit (HQT), which provides model measurement and quantization capabilities in PyTorch.
+Llama2-70b, Llama2-7b,  Mistral-7b, Mixtral-8x7B, Falcon-7B, Falcon-40B, and Falcon-180B in FP8 are enabled using the Quantization Toolkit (HQT), which provides model measurement and quantization capabilities in PyTorch.
 
 More information on enabling fp8 in SynapseAI is available here:
 https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_FP8.html

--- a/examples/text-generation/run_lm_eval.py
+++ b/examples/text-generation/run_lm_eval.py
@@ -75,13 +75,13 @@ class HabanaModelAdapter(lm_eval.base.BaseLM):
         self.options = options
         self._device = args.device
         self.model_inputs = {"use_cache": self.options.use_cache}
-        if self.model.config.model_type in ["llama", "falcon"]:
+        if self.model.config.model_type in ["llama", "mistral", "falcon"]:
             self.model_inputs.update(
                 {
                     "reuse_cache": self.options.reuse_cache,
                 }
             )
-        if self.model.config.model_type == "llama":
+        if self.model.config.model_type in ["llama", "mistral"]:
             self.model_inputs.update(
                 {
                     "attn_softmax_bf16": self.options.attn_softmax_bf16,

--- a/optimum/habana/transformers/models/mistral/modeling_mistral.py
+++ b/optimum/habana/transformers/models/mistral/modeling_mistral.py
@@ -278,14 +278,6 @@ class GaudiMistralAttention(MistralAttention):
                         attn_output = FusedSDPA.apply(
                             query_states, key_states, value_states, attention_mask, 0.0, False, None
                         )
-        elif FusedSDPA and not self.training and q_len == key_states.size(-2) and q_len > 8192:
-            # support long sequences exceeding 8192
-            # for shorter sequences, do not use fusedSDPA(due to perf degradation)
-            import habana_frameworks.torch.hpu as ht
-
-            use_recompute = True if os.getenv("QUANT_CONFIG", "") else False
-            with ht.sdp_kernel(enable_recompute=use_recompute):
-                attn_output = FusedSDPA.apply(query_states, key_states, value_states, attention_mask, 0.0, False, None)
         else:
             # repeat k/v heads if n_kv_heads < n_heads
             query_states, key_states, value_states, attention_mask = gaudi_mistral_repeat_kv(


### PR DESCRIPTION
# What does this PR do?

Add support for Mistral fp8 text-generation. 
Porting from: 
https://github.com/huggingface/optimum-habana/pull/918 
https://github.com/huggingface/optimum-habana/pull/931

## Measurement
`QUANT_CONFIG=./quantization_config/maxabs_measure_include_outputs.json python  run_generation.py  --model_name_or_path mistralai/Mistral-7B-Instruct-v0.2 --attn_softmax_bf16 --use_hpu_graphs --trim_logits --use_kv_cache --reuse_cache --bf16 --batch_size `

## Run
### 128x128xbs896
` QUANT_CONFIG=./quantization_config/maxabs_quant.json python run_generation.py --model_name_or_path mistralai/Mistral-7B-Instruct-v0.2 --attn_softmax_bf16 --use_hpu_graphs --trim_logits --use_kv_cache --reuse_cache --bf16 --batch_size 896  --max_new_tokens 128 --max_input_tokens 128 --limit_hpu_graphs`

Throughput (including tokenization) = 13235.770108332108 tokens/second
Number of HPU graphs                = 91
Memory allocated                    = 38.35 GB
Max memory allocated                = 92.85 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 72.49320212705061 seconds

 
 ### 2048x128xbs120
` QUANT_CONFIG=./quantization_config/maxabs_quant.json python run_generation.py --model_name_or_path mistralai/Mistral-7B-Instruct-v0.2 --attn_softmax_bf16 --use_hpu_graphs --trim_logits --use_kv_cache --reuse_cache --bf16 --batch_size 120  --max_new_tokens 128 --max_input_tokens 2048 --limit_hpu_graph`

 Throughput (including tokenization) = 1368.34859681789 tokens/second
Number of HPU graphs                = 85
Memory allocated                    = 74.29 GB
Max memory allocated                = 93.3 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 71.46055008197436 seconds

 ### 2048x2048xbs44
` QUANT_CONFIG=./quantization_config/maxabs_quant.json python run_generation.py --model_name_or_path mistralai/Mistral-7B-Instruct-v0.2 --attn_softmax_bf16 --use_hpu_graphs --trim_logits --use_kv_cache --reuse_cache --bf16 --batch_size 44 --max_new_tokens 2048 --max_input_tokens 2048 --bucket_internal --bucket_size 128  --limit_hpu_graphs `

Throughput (including tokenization) = 3151.661188904903 tokens/second
Number of HPU graphs                = 565
Memory allocated                    = 84.73 GB
Max memory allocated                = 94.44 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 285.3293136919965 seconds

### 128x2048xbs120
`QUANT_CONFIG=./quantization_config/maxabs_quant.json python run_generation.py --model_name_or_path mistralai/Mistral-7B-Instruct-v0.2 --attn_softmax_bf16 --use_hpu_graphs --trim_logits --use_kv_cache --reuse_cache --bf16 --batch_size 120 --max_new_tokens 2048 --max_input_tokens 128 --bucket_internal --bucket_size 128  --limit_hpu_graphs`

Throughput (including tokenization) = 7957.2094113766125 tokens/second
Number of HPU graphs                = 565
Memory allocated                    = 74.96 GB
Max memory allocated                = 94.09 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 278.0657788790413 seconds

### 32000x512xbs4 
#### Flash attention with fp16
`python run_generation.py  --model_name_or_path mistralai/Mistral-7B-Instruct-v0.2 --attn_softmax_bf16 --use_hpu_graphs --trim_logits --use_kv_cache --reuse_cache --bf16 --batch_size 4 --max_new_tokens 512 --max_input_tokens 32000  --use_flash_attention --flash_attention_recompute --flash_attention_causal_mask`

Throughput (including tokenization) = 56.17350039654345 tokens/second
Number of HPU graphs                = 17
Memory allocated                    = 90.82 GB
Max memory allocated                = 90.84 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 112.64211278100265 seconds

#### Fused SDPA with fp8
`QUANT_CONFIG=./quantization_config/maxabs_quant.json python run_generation.py --model_name_or_path mistralai/Mistral-7B-Instruct-v0.2 --attn_softmax_bf16 --use_hpu_graphs --trim_logits --use_kv_cache --reuse_cache --bf16 --batch_size 4 --max_new_tokens 512 --max_input_tokens 32000 --limit_hpu_graphs`

Throughput (including tokenization) = 42.383026178121916 tokens/second
Number of HPU graphs                = 85
Memory allocated                    = 33.55 GB
Max memory allocated                = 77.12 GB
Total memory available              = 94.62 GB
Graph compilation duration          = 199.3312814909732 seconds
