### PR TITLE
Assign grad_norm for logging only if it's a single element tensor

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -1175,12 +1175,16 @@ class GaudiTrainer(Trainer):
             if is_accelerate_available() and self.accelerator.distributed_type == GaudiDistributedType.DEEPSPEED:
                 grad_norm = model.get_global_grad_norm()
             else:
-                if _grad_norm is not None and self.accelerator.distributed_type != GaudiDistributedType.FSDP:
-                    grad_norm = _grad_norm.item() if _grad_norm.size() == torch.Size([1]) else _grad_norm.tolist()
+                if (
+                    _grad_norm is not None
+                    and self.accelerator.distributed_type != GaudiDistributedType.FSDP
+                    and _grad_norm.size() == torch.Size([1])
+                ):
+                    grad_norm = _grad_norm.item()
                 else:
                     grad_norm = None
 
-            if grad_norm is not None and not isinstance(grad_norm, list):
+            if grad_norm is not None:
                 logs["grad_norm"] = grad_norm
             logs["learning_rate"] = self._get_learning_rate()
 


### PR DESCRIPTION
Port from https://github.com/huggingface/optimum-habana/pull/992

We have a condition check if the grad_norm tensor is a single element or not. If it's not we convert grad_norm as list.
(https://github.com/huggingface/optimum-habana/pull/938)
But for logging, we don't use grad_norm if it's a list so there's no point to get grad_norm list.
I changed condition to check if grad_norm is a list just assign None.

We see that this list conversion causes a perf issue.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
