### PR TITLE
Updating the huggingface-hub version required for optimum-habana

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ INSTALL_REQUIRES = [
     "accelerate < 0.28.0",
     "diffusers >= 0.26.0, < 0.27.0",
     "pytest < 8.0.0",
-    "huggingface_hub < 0.23.0",
+    "huggingface_hub <= 0.23.1",
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
# What does this PR do?
Updates the huggingface-hub version range supported for optimum-habana installation

Previously supported versions are < 0.23.0, this PR will update it to <= 0.23.1
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
The optimum-habana installation issue, which fails complaining that Requirement.parse('huggingface_hub<=0.23.0'), {'optimum-habana'})
This is because datasets python package installs huggingface-hub latest version which is 0.23.1 and this causes a mismatch while installing optimum-habana which requires < 0.23.0

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
