### PR TITLE
Fix for ValueError:Cannot get 16bit model weights because `stage3_gather_16bit_weights_on_model_save` in DeepSpeed config is False

### DIFF
--- a/examples/summarization/ds_flan_t5_z3_config_bf16.json
+++ b/examples/summarization/ds_flan_t5_z3_config_bf16.json
@@ -32,7 +32,7 @@
     "stage3_param_persistence_threshold": "auto",
     "stage3_max_live_parameters": 1e9,
     "stage3_max_reuse_distance": 1e9,
-    "stage3_gather_16bit_weights_on_model_save": false
+    "stage3_gather_16bit_weights_on_model_save": true
   },
   "gradient_accumulation_steps": "auto",
   "gradient_clipping": "auto",


### PR DESCRIPTION

When running with torch_compile enabled, a ValueError is seen (as mentioned in title) at the end of training.
Setting this flag to true bypasses the error.