### PR TITLE
Use fast softmax only on prefill

### DIFF
--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -429,7 +429,7 @@ class GaudiLlamaAttention(LlamaAttention):
             if q_len == 1:
                 # next token
                 attn_output = self.fused_scaled_dot_product_attention(
-                    query_states, key_states, value_states, attention_mask, 0.0, False, None, softmax_mode, self.use_recompute
+                    query_states, key_states, value_states, attention_mask, 0.0, False, None, 'None', self.use_recompute
                 )
             else:
                 # first token


### PR DESCRIPTION
Currently running fast softmax on decode can cause perf degradation on some configs. Thus this PR turns it off for decode.

Results:

Model | Batch Size | Nodes | Performance with Fast Softmax (Prefill Only) | Performance without Fast Softmax
------|------------|-------|---------------------------------------------|----------------------------------
Llama 2-70B 31744/1024 Tokens | 12 | 8 | 105.27 | 97.08
Llama 2-70B 24576/8192 Tokens | 16 | 8 | 418.95 | 405.55
Llama 2-70B 16384/16384 Tokens | 24 | 8 | 673.99 | 665.84
Llama 2-70B 4096/4096 Tokens | 16 | 2 | 304.17 | 303.75
Llama 2-70B 4096/4096 Tokens | 59 | 4 | 1149.75 | 1147.10