### PR TITLE
Import TE module conditionally

### DIFF
--- a/optimum/habana/accelerate/utils/transformer_engine.py
+++ b/optimum/habana/accelerate/utils/transformer_engine.py
@@ -16,16 +16,21 @@
 import functools
 import torch
 
-try:
-    import habana_frameworks.torch.hpex.experimental.transformer_engine as te
-    from habana_frameworks.torch.hpex.experimental.transformer_engine.distributed import activation_checkpointing
+has_transformer_engine = False
 
-    has_transformer_engine = True
-except ImportError:
-    has_transformer_engine = False
+def import_te():
+    global te, has_transformer_engine
+    try:
+        import habana_frameworks.torch.hpex.experimental.transformer_engine as te
+        has_transformer_engine = True
+
+    except ImportError:
+        has_transformer_engine = False
 
 
 def is_fp8_available():
+    if not has_transformer_engine:
+        import_te()
     return has_transformer_engine
 
 
@@ -89,6 +94,8 @@ def get_fp8_recipe(fp8_recipe_handler):
     Creates transformer engine FP8 recipe object.
     Adapted from: https://github.com/huggingface/accelerate/blob/v0.27.2/src/accelerate/accelerator.py#L1309
     """
+    if not is_fp8_available():
+        raise ImportError("Using `has_transformer_engine_layers` requires transformer_engine to be installed.")
     kwargs = fp8_recipe_handler.to_dict() if fp8_recipe_handler is not None else {}
     if "fp8_format" in kwargs:
         kwargs["fp8_format"] = getattr(te.recipe.Format, kwargs["fp8_format"])
@@ -123,7 +130,7 @@ class FP8ContextWrapper:
         below wraps this first argument with `transformer_engine`'s `activation_checkpointing` context.
         '''
         _args = list(args)
-        _args[0] = activation_checkpointing()(_args[0])
+        _args[0] = te.distributed.activation_checkpointing()(_args[0])
         args = tuple(_args)
 
         return func(*args, **kwargs)

--- a/optimum/habana/accelerate/utils/transformer_engine.py
+++ b/optimum/habana/accelerate/utils/transformer_engine.py
@@ -95,7 +95,7 @@ def get_fp8_recipe(fp8_recipe_handler):
     Adapted from: https://github.com/huggingface/accelerate/blob/v0.27.2/src/accelerate/accelerator.py#L1309
     """
     if not is_fp8_available():
-        raise ImportError("Using `has_transformer_engine_layers` requires transformer_engine to be installed.")
+        raise ImportError("Using `get_fp8_recipe` requires transformer_engine to be installed.")
     kwargs = fp8_recipe_handler.to_dict() if fp8_recipe_handler is not None else {}
     if "fp8_format" in kwargs:
         kwargs["fp8_format"] = getattr(te.recipe.Format, kwargs["fp8_format"])


### PR DESCRIPTION
hccl gets imported before the env flags are set due an initial transformer_engine import causing following error from bridge
"RuntimeError: collective nonSFG is not supported during hpu graph capturing"

Fixed this by importing TE only for training fp8 use-cases (--fp8 argument set by user).