### PR TITLE
Restring datasets package version to < 2.20.0 for Contrastive image text

### DIFF
--- a/examples/contrastive-image-text/requirements.txt
+++ b/examples/contrastive-image-text/requirements.txt
@@ -1,1 +1,1 @@
-datasets>=1.8.0
+datasets>=1.8.0,<2.20.0


### PR DESCRIPTION

# What does this PR do?
Restrict the datasets package requirements to < 2.2.0 version in case of
Contrastive-image-text models
the latest datastets == 2.2.0

Fixes # (issue)
Fixes the issue while loading the dataset for models in Contrastive image text while using
datasets 2.2.0 because it expects a new flag "trust_remote_code" to be set to True
to read data sets from Hugging face

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
