### PR TITLE
Allow torch.compile execution for other than Llama text-generation models

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -333,7 +333,7 @@ def main():
     model, tokenizer, generation_config = initialize_model(args, logger)
 
     use_lazy_mode = True
-    if args.torch_compile and model.config.model_type == "llama":
+    if args.torch_compile:
         use_lazy_mode = False
 
     import habana_frameworks.torch.hpu as torch_hpu


### PR DESCRIPTION
# What does this PR do?
- allows to execute with torch.compile mode for other than Llama model in text-generation example
- makes Mixtral to run mark_step only in case of lazy in order to avoid redundant warnings

