### PR TITLE
Fix t.compile for Granite20b  

### DIFF
--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -177,7 +177,10 @@ def patch_scoped_linear_all_reduce(model):
 
 
 def get_torch_compiled_model(model):
-    model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
+    if  model.config.model_type in ['gpt_bigcode']:
+      model.transformer = torch.compile(model.transformer, backend="hpu_backend", options={"keep_input_mutations": True})
+    else:
+      model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
     return model
 
 

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -178,10 +178,7 @@ def patch_scoped_linear_all_reduce(model):
 
 def get_torch_compiled_model(model):
     if  model.config.model_type in ['gpt_bigcode']:
-<<<<<<< HEAD
-=======
-      # For gpt_bigcode, model.transformer is used instead of model.model
->>>>>>> debbae8 (Enable t.compile for Granite20B)
+      # For gpt_bigcode model_type, model.transformer is used instead of model.model
       model.transformer = torch.compile(model.transformer, backend="hpu_backend", options={"keep_input_mutations": True})
     else:
       model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -178,6 +178,10 @@ def patch_scoped_linear_all_reduce(model):
 
 def get_torch_compiled_model(model):
     if  model.config.model_type in ['gpt_bigcode']:
+<<<<<<< HEAD
+=======
+      # For gpt_bigcode, model.transformer is used instead of model.model
+>>>>>>> debbae8 (Enable t.compile for Granite20B)
       model.transformer = torch.compile(model.transformer, backend="hpu_backend", options={"keep_input_mutations": True})
     else:
       model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})


### PR DESCRIPTION
# What does this PR do?

<!--
Granite20B model uses the GPTBigCode model type. In this model,
model object uses model.transformer instead of model.model for the actual
model. This is a pointed fix for this model, in future other models
may need similar change.
-->
