### PR TITLE
Fix nan eval loss in clip training

### DIFF
--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -1861,12 +1861,8 @@ class GaudiTrainer(Trainer):
             if loss is not None:
                 # Handle NaN loss
                 if args.logging_nan_inf_filter and (torch.isnan(loss) or torch.isinf(loss)):
-                    # If loss is NaN or Inf, use the average of previous losses or a small constant
-                    if losses_host is not None and len(losses_host) > 0:
-                        avg_loss = torch.mean(losses_host)
-                        loss = avg_loss
-                    else:
-                        loss = torch.tensor(1e-8, device=loss.device)
+                    # If loss is NaN or Inf, use a small constant
+                    loss = torch.tensor(1e-8, device=loss.device)
 
                 losses = self.gather_function((loss.repeat(batch_size)))
                 all_losses.add(losses)


### PR DESCRIPTION
Fix nan eval loss in contrastive-image-text clip-roberta training.

Otherwise, get "losses_host not defined" error