### PR TITLE
Support for valid sequence length feature in FusedSDPA for llama

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -606,6 +606,11 @@ def main():
                     max_length=args.max_input_tokens,
                     truncation=True,
                 )
+                def compute_valid_sequence_lengths_tensor(input_tokens):
+                    attn_mask = input_tokens['attention_mask']
+                    return torch.sum(attn_mask, dim=1)
+                valid_sequence_lengths = compute_valid_sequence_lengths_tensor(input_tokens).to(args.device)
+                setattr(generation_config, 'valid_sequence_lengths', valid_sequence_lengths)
             else:
                 input_tokens = tokenizer.batch_encode_plus(input_sentences, return_tensors="pt", padding=True)
             encode_duration = time.perf_counter() - encode_t0

--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1000,6 +1000,7 @@ class GaudiGenerationMixin(GenerationMixin):
         )
         model_kwargs["num_virtual_tokens"] = num_virtual_tokens
 
+        model_kwargs["valid_sequence_lengths"] = generation_config.valid_sequence_lengths
         if not self.config.is_encoder_decoder:
             calculated_max_length = input_ids.shape[-1] + num_virtual_tokens
             if not generation_config.static_shapes and generation_config.max_new_tokens is not None:

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -272,15 +272,14 @@ def gaudi_llama_repeat_kv(
 
     return query_states, key_states, value_states, attention_mask
 
-
 #  FusedScaledDotProductAttention
 class ModuleFusedSDPA(torch.nn.Module):
     def __init__(self, fusedSDPA):
         super().__init__()
         self._hpu_kernel_fsdpa = fusedSDPA
 
-    def forward(self, query, key, value, attn_mask, dropout_p, is_casual, scale, softmax_mode):
-        return self._hpu_kernel_fsdpa.apply(query, key, value, attn_mask, dropout_p, is_casual, scale, softmax_mode)
+    def forward(self, query, key, value, attn_mask, dropout_p, is_casual, scale, softmax_mode, recompute_mode, valid_sequence_lengths, padding_side="left"):
+        return  self._hpu_kernel_fsdpa.apply(query, key, value, attn_mask, dropout_p, is_casual, scale, softmax_mode, recompute_mode, valid_sequence_lengths, padding_side)
 
 
 class Matmul(torch.nn.Module):
@@ -416,6 +415,7 @@ class GaudiLlamaAttention(LlamaAttention):
         flash_attention_recompute: Optional[bool] = False,
         flash_attention_causal_mask: Optional[bool] = False,
         flash_attention_fast_softmax: Optional[bool] = False,
+        valid_sequence_lengths: torch.Tensor = None,
         cache_idx: int = None,
         num_virtual_tokens: int = None,
         **kwargs,
@@ -537,23 +537,19 @@ class GaudiLlamaAttention(LlamaAttention):
             if q_len == 1:
                 # next token
                 use_recompute = True if os.getenv("QUANT_CONFIG", "") else False
-                with ht.sdp_kernel(enable_recompute=use_recompute):
-                    attn_output = self.fused_scaled_dot_product_attention(
-                        query_states, key_states, value_states, attention_mask, 0.0, False, None, 'None'
-                    )
+                attn_output = self.fused_scaled_dot_product_attention(
+                    query_states, key_states, value_states, attention_mask, 0.0, False, None, softmax_mode, use_recompute, None, "None"
+                )
             else:
                 # first token
                 if flash_attention_causal_mask:
-                    # causal masking on first token requires inputs to be of the same length
-                    with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
-                        attn_output = self.fused_scaled_dot_product_attention(
-                            query_states, key_states, value_states, None, 0.0, True, None, softmax_mode
-                        )
+                    attn_output = self.fused_scaled_dot_product_attention(
+                        query_states, key_states, value_states, None, 0.0, True, None, softmax_mode, flash_attention_recompute, valid_sequence_lengths, "left"
+                    )
                 else:
-                    with ht.sdp_kernel(enable_recompute=flash_attention_recompute):
-                        attn_output = self.fused_scaled_dot_product_attention(
-                            query_states, key_states, value_states, attention_mask, 0.0, False, None, softmax_mode
-                        )
+                    attn_output = self.fused_scaled_dot_product_attention(
+                        query_states, key_states, value_states, attention_mask, 0.0, False, None, softmax_mode,flash_attention_recompute, None, "None"
+                    )
 
         else:
             query_states, key_states, value_states, attention_mask = gaudi_llama_repeat_kv(
@@ -735,6 +731,7 @@ class GaudiLlamaDecoderLayer(LlamaDecoderLayer):
         flash_attention_recompute: Optional[bool] = False,
         flash_attention_causal_mask: Optional[bool] = False,
         flash_attention_fast_softmax: Optional[bool] = False,
+        valid_sequence_lengths: torch.Tensor = None,
         cache_idx: int = None,
         num_virtual_tokens: int = None,
         **kwargs,
@@ -771,6 +768,7 @@ class GaudiLlamaDecoderLayer(LlamaDecoderLayer):
             flash_attention_recompute=flash_attention_recompute,
             flash_attention_causal_mask=flash_attention_causal_mask,
             flash_attention_fast_softmax=flash_attention_fast_softmax,
+            valid_sequence_lengths=valid_sequence_lengths,
             cache_idx=cache_idx,
             num_virtual_tokens=num_virtual_tokens,
             **kwargs,
@@ -805,6 +803,7 @@ class GaudiLlamaDecoderLayer(LlamaDecoderLayer):
         flash_attention_recompute: Optional[bool] = False,
         flash_attention_causal_mask: Optional[bool] = False,
         flash_attention_fast_softmax: Optional[bool] = False,
+        valid_sequence_lengths: torch.Tensor = None,
         cache_idx: int = None,
         num_virtual_tokens: int = None,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
@@ -824,6 +823,7 @@ class GaudiLlamaDecoderLayer(LlamaDecoderLayer):
             flash_attention_recompute,
             flash_attention_causal_mask,
             flash_attention_fast_softmax,
+            valid_sequence_lengths,
             cache_idx=cache_idx,
             num_virtual_tokens=num_virtual_tokens,
         )
@@ -917,6 +917,7 @@ class GaudiLlamaModel(LlamaModel):
         flash_attention_recompute: Optional[bool] = False,
         flash_attention_causal_mask: Optional[bool] = False,
         flash_attention_fast_softmax: Optional[bool] = False,
+        valid_sequence_lengths: torch.Tensor = None,
         cache_idx: int = None,
         lazy_mode: Optional[bool] = True,
         num_virtual_tokens: int = None,
@@ -1053,6 +1054,7 @@ class GaudiLlamaModel(LlamaModel):
                     flash_attention_recompute,
                     flash_attention_causal_mask,
                     flash_attention_fast_softmax,
+                    valid_sequence_lengths,
                     None,
                 )
             else:
@@ -1071,6 +1073,7 @@ class GaudiLlamaModel(LlamaModel):
                     flash_attention_recompute=flash_attention_recompute,
                     flash_attention_causal_mask=flash_attention_causal_mask,
                     flash_attention_fast_softmax=flash_attention_fast_softmax,
+                    valid_sequence_lengths=valid_sequence_lengths,
                     cache_idx=cache_idx,
                     num_virtual_tokens=num_virtual_tokens,
                 )
@@ -1149,6 +1152,7 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
         flash_attention_recompute: Optional[bool] = False,
         flash_attention_causal_mask: Optional[bool] = False,
         flash_attention_fast_softmax: Optional[bool] = False,
+        valid_sequence_lengths: torch.Tensor = None,
         cache_idx: int = None,
         lazy_mode: Optional[bool] = True,
         num_virtual_tokens: int = None,
@@ -1181,6 +1185,7 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
             flash_attention_recompute=flash_attention_recompute,
             flash_attention_causal_mask=flash_attention_causal_mask,
             flash_attention_fast_softmax=flash_attention_fast_softmax,
+            valid_sequence_lengths=valid_sequence_lengths,
             cache_idx=cache_idx,
             lazy_mode=lazy_mode,
             num_virtual_tokens=num_virtual_tokens,
@@ -1322,6 +1327,7 @@ class GaudiLlamaForCausalLM(LlamaForCausalLM):
                 "flash_attention_recompute": kwargs.get("flash_attention_recompute"),
                 "flash_attention_causal_mask": kwargs.get("flash_attention_causal_mask"),
                 "flash_attention_fast_softmax": kwargs.get("flash_attention_fast_softmax"),
+                "valid_sequence_lengths": kwargs.get("valid_sequence_lengths"),
                 "cache_idx": kwargs.get("cache_idx"),
                 "lazy_mode": kwargs.get("lazy_mode"),
                 "num_virtual_tokens": kwargs.get("num_virtual_tokens"),

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -536,9 +536,8 @@ class GaudiLlamaAttention(LlamaAttention):
 
             if q_len == 1:
                 # next token
-                use_recompute = True if os.getenv("QUANT_CONFIG", "") else False
                 attn_output = self.fused_scaled_dot_product_attention(
-                    query_states, key_states, value_states, attention_mask, 0.0, False, None, softmax_mode, use_recompute, None, "None"
+                    query_states, key_states, value_states, attention_mask, 0.0, False, None, softmax_mode, False, None, "None"
                 )
             else:
                 # first token


### PR DESCRIPTION
Valid sequence length (VSL) feature provides a way of indicating to the FusedSDPA operator which part of inputs contain valid information and which are just padding. Thanks to that operator can skip unnecessary computation which improves performance.

This change also enables using "causal" flag for the prefill in case inputs are of different length. Previously using causal with different length of inputs would cause padding to be included in computation which caused degradation in accuracy.


Below is performance data showcasing the improvement in the model with causal flag:

BS - batch size
MIT - max input tokens
MNT - max new tokens
VSL - valid sequence lengths

BF16:

BS | MIT | MNT | Causal - Lower Triangular Softmax (Through VSL Feature) | Throughput (Including Tokenization) Tokens/s | Improvement vs. Without Causal [%]
-- | -- | -- | -- | -- | --
12 | 31744 | 1024 | 0 | 104.79 |  
12 | 31744 | 1024 | 1 | 182.095 | 53.89
16 | 24576 | 8192 | 0 | 401.74 |  
16 | 24576 | 8192 | 1 | 455.85 | 12.62
24 | 16384 | 16384 | 0 | 623.25 |  
24 | 16384 | 16384 | 1 | 649.78 | 4.17
48 | 8192 | 8192 | 0 | 1242.62 |  
48 | 8192 | 8192 | 1 | 1285.92 | 3.42
96 | 4096 | 4096 | 0 | 2368.83 |

FP8:

BS | MIT | MNT | Causal - Lower Triangular Softmax (Through VSL Feature) | Throughput (including   tokenization) tokens/s | Improvement vs without causal [%]
-- | -- | -- | -- | -- | --
1230 | 128 | 128 | 0 | 13400.8 |  
1230 | 128 | 128 | 1 | 13652.56 | 1.86
225 | 2048 | 2048 | 0 | 5244.52 |  
225 | 2048 | 2048 | 1 | 5384.09 | 2.63
114 | 4096 | 4096 | 0 | 3441.98 |  
114 | 4096 | 4096 | 1 | 3507.86 | 1.90
37 | 8192 | 8192 | 0 | 1261.14 |  
37 | 8192 | 8192 | 1 | 1321.64 | 4.68

