### PR TITLE
Test Habana's PT2E-quantization flow with Llama2

### DIFF
--- a/examples/text-generation/experimental/run_generation.py
+++ b/examples/text-generation/experimental/run_generation.py
@@ -1,0 +1,927 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2018 Google AI, Google Brain and Carnegie Mellon University Authors and the HuggingFace Inc. team.
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Conditional text generation on Habana Gaudi/Gaudi2.
+"""
+
+import argparse
+import json
+import logging
+import math
+import os
+import struct
+import time
+from itertools import cycle
+from pathlib import Path
+
+import pandas as pd
+import torch
+from utils import adjust_batch, count_hpu_graphs, finalize_quantization, initialize_model
+
+from optimum.habana.utils import get_hpu_memory_stats
+
+
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+
+def setup_parser(parser):
+    class StoreTrueFalseAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            if isinstance(values, bool) or values is None:
+                # Flag passed without any value -> set to True
+                setattr(namespace, self.dest, True)
+            else:
+                # Flag passed with value -> pattern match and set accordingly
+                value_str = values.lower()
+                if value_str in ("true", "1", "yes"):
+                    setattr(namespace, self.dest, True)
+                elif value_str in ("false", "0", "no"):
+                    setattr(namespace, self.dest, False)
+                else:
+                    raise ValueError(f"Invalid value for {option_string}: {values}")
+
+    # Arguments management
+    parser.add_argument("--device", "-d", type=str, choices=["hpu"], help="Device to run", default="hpu")
+    parser.add_argument(
+        "--model_name_or_path",
+        default=None,
+        type=str,
+        required=True,
+        help="Path to pre-trained model (on the HF Hub or locally).",
+    )
+    parser.add_argument(
+        "--bf16",
+        action="store_true",
+        help="Whether to perform generation in bf16 precision.",
+    )
+    parser.add_argument("--max_new_tokens", type=int, default=100, help="Number of tokens to generate.")
+    parser.add_argument(
+        "--max_input_tokens",
+        type=int,
+        default=0,
+        help="If > 0 then pad and truncate the input sequences to this specified length of tokens. \
+            if == 0, then truncate to 16 (original default) \
+            if < 0, then do not truncate, use full input prompt",
+    )
+    parser.add_argument("--batch_size", type=int, default=1, help="Input batch size.")
+    parser.add_argument("--warmup", type=int, default=3, help="Number of warmup iterations for benchmarking.")
+    parser.add_argument("--n_iterations", type=int, default=5, help="Number of inference iterations for benchmarking.")
+    parser.add_argument("--local_rank", type=int, default=0, metavar="N", help="Local process rank.")
+    parser.add_argument(
+        "--use_kv_cache",
+        action="store_true",
+        help="Whether to use the key/value cache for decoding. It should speed up generation.",
+    )
+    parser.add_argument(
+        "--use_hpu_graphs",
+        action="store_true",
+        help="Whether to use HPU graphs or not. Using HPU graphs should give better latencies.",
+    )
+    parser.add_argument(
+        "--dataset_name",
+        default=None,
+        type=str,
+        help="Optional argument if you want to assess your model on a given dataset of the HF Hub.",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="/mnt/weka/data/mlperf_inference/llama2/processed-data.pkl",
+        type=str,
+        help="path of the dataset to run rouge evaluation and measurement for rouge",
+    )
+    parser.add_argument(
+        "--column_name",
+        default=None,
+        type=str,
+        help="If `--dataset_name` was given, this will be the name of the column to use as prompts for generation.",
+    )
+    parser.add_argument(
+        "--do_sample",
+        action="store_true",
+        help="Whether to use sampling for generation.",
+    )
+    parser.add_argument(
+        "--num_beams",
+        default=1,
+        type=int,
+        help="Number of beams used for beam search generation. 1 means greedy search will be performed.",
+    )
+    parser.add_argument(
+        "--trim_logits",
+        action="store_true",
+        help="Calculate logits only for the last token to save memory in the first step.",
+    )
+    parser.add_argument(
+        "--seed",
+        default=27,
+        type=int,
+        help="Seed to use for random generation. Useful to reproduce your runs with `--do_sample`.",
+    )
+    parser.add_argument(
+        "--profiling_warmup_steps",
+        default=0,
+        type=int,
+        help="Number of steps to ignore for profiling.",
+    )
+    parser.add_argument(
+        "--profiling_steps",
+        default=0,
+        type=int,
+        help="Number of steps to capture for profiling.",
+    )
+    parser.add_argument(
+        "--profiling_record_shapes",
+        default=False,
+        type=bool,
+        help="Record shapes when enabling profiling.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        type=str,
+        nargs="*",
+        help='Optional argument to give a prompt of your choice as input. Can be a single string (eg: --prompt "Hello world"), or a list of space-separated strings (eg: --prompt "Hello world" "How are you?")',
+    )
+    parser.add_argument(
+        "--bad_words",
+        default=None,
+        type=str,
+        nargs="+",
+        help="Optional argument list of words that are not allowed to be generated.",
+    )
+    parser.add_argument(
+        "--force_words",
+        default=None,
+        type=str,
+        nargs="+",
+        help="Optional argument list of words that must be generated.",
+    )
+    parser.add_argument(
+        "--assistant_model",
+        default=None,
+        type=str,
+        help="Optional argument to give a path to a draft/assistant model for assisted decoding.",
+    )
+    parser.add_argument(
+        "--peft_model",
+        default=None,
+        type=str,
+        help="Optional argument to give a path to a PEFT model.",
+    )
+    parser.add_argument("--num_return_sequences", type=int, default=1)
+    parser.add_argument(
+        "--token",
+        default=None,
+        type=str,
+        help="The token to use as HTTP bearer authorization for remote files. If not specified, will use the token "
+        "generated when running `huggingface-cli login` (stored in `~/.huggingface`).",
+    )
+    parser.add_argument(
+        "--model_revision",
+        default="main",
+        type=str,
+        help="The specific model version to use (can be a branch name, tag name or commit id).",
+    )
+    parser.add_argument(
+        "--attn_softmax_bf16",
+        action="store_true",
+        help="Whether to run attention softmax layer in lower precision provided that the model supports it and "
+        "is also running in lower precision.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        default=None,
+        type=str,
+        help="Output directory to store results in.",
+    )
+    parser.add_argument(
+        "--bucket_size",
+        default=-1,
+        type=int,
+        help="Bucket size to maintain static shapes. If this number is negative (default is -1) \
+            then we use `shape = prompt_length + max_new_tokens`. If a positive number is passed \
+            we increase the bucket in steps of `bucket_size` instead of allocating to max (`prompt_length + max_new_tokens`).",
+    )
+    parser.add_argument(
+        "--bucket_internal",
+        action="store_true",
+        help="Split kv sequence into buckets in decode phase. It improves throughput when max_new_tokens is large.",
+    )
+    parser.add_argument(
+        "--dataset_max_samples",
+        default=-1,
+        type=int,
+        help="If a negative number is passed (default = -1) perform inference on the whole dataset, else use only `dataset_max_samples` samples.",
+    )
+    parser.add_argument(
+        "--limit_hpu_graphs",
+        action="store_true",
+        help="Skip HPU Graph usage for first token to save memory",
+    )
+    parser.add_argument(
+        "--reuse_cache",
+        action="store_true",
+        help="Whether to reuse key/value cache for decoding. It should save memory.",
+    )
+    parser.add_argument("--verbose_workers", action="store_true", help="Enable output from non-master workers")
+    parser.add_argument(
+        "--simulate_dyn_prompt",
+        default=None,
+        type=int,
+        nargs="*",
+        help="If empty, static prompt is used. If a comma separated list of integers is passed, we warmup and use those shapes for prompt length.",
+    )
+    parser.add_argument(
+        "--reduce_recompile",
+        action="store_true",
+        help="Preprocess on cpu, and some other optimizations. Useful to prevent recompilations when using dynamic prompts (simulate_dyn_prompt)",
+    )
+
+    parser.add_argument("--gptq", action="store_true", help="Enable Quantization to 4 bit with AutoGPTQ")
+
+    parser.add_argument(
+        "--use_flash_attention",
+        nargs="?",
+        const=True,
+        default=False,
+        action=StoreTrueFalseAction,
+        help="Whether to enable Habana Flash Attention, provided that the model supports it.",
+    )
+    parser.add_argument(
+        "--flash_attention_recompute",
+        nargs="?",
+        const=True,
+        default=False,
+        action=StoreTrueFalseAction,
+        help="Whether to enable Habana Flash Attention in recompute mode on first token generation. This gives an opportunity of splitting graph internally which helps reduce memory consumption.",
+    )
+    parser.add_argument(
+        "--flash_attention_causal_mask",
+        nargs="?",
+        const=True,
+        default=False,
+        action=StoreTrueFalseAction,
+        help="Whether to enable Habana Flash Attention in causal mode on first token generation.",
+    )
+    parser.add_argument(
+        "--flash_attention_fast_softmax",
+        nargs="?",
+        const=None,  # Default value handled post-parsing
+        action=StoreTrueFalseAction,
+        help="Whether to enable Habana Flash Attention in fast softmax mode.",
+    )
+    parser.add_argument(
+        "--book_source",
+        action="store_true",
+        help="Whether to use project Guttenberg books data as input. Usefull for testing large sequence lenghts.",
+    )
+    parser.add_argument(
+        "--torch_compile",
+        action="store_true",
+        help="Whether to use torch compiled model or not.",
+    )
+    parser.add_argument(
+        "--ignore_eos",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Whether to ignore eos, set False to disable it",
+    )
+    parser.add_argument("--temperature", default=1.0, type=float, help="Temperature value for text generation")
+    parser.add_argument("--top_p", default=1.0, type=float, help="Top_p value for generating text via sampling")
+    parser.add_argument(
+        "--const_serialization_path",
+        "--csp",
+        type=str,
+        help="Path to serialize const params. Const params will be held on disk memory instead of being allocated on host memory.",
+    )
+    parser.add_argument(
+        "--disk_offload",
+        action="store_true",
+        help="Whether to enable device map auto. In case no space left on cpu, weights will be offloaded to disk.",
+    )
+    parser.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        help="Whether or not to allow for custom models defined on the Hub in their own modeling files.",
+    )
+    parser.add_argument(
+        "--run_partial_dataset",
+        action="store_true",
+        help="Run the inference with dataset for specified --n_iterations(default:5)",
+    )
+    parser.add_argument(
+        "--load_cp",
+        action="store_true",
+        help="Whether to load model from hugging face checkpoint.",
+    )
+    parser.add_argument(
+        "--parallel_strategy",
+        type=str,
+        choices=["tp", "none"],  # Add other strategies as needed
+        default="none",
+        help="Run multi card with the specified parallel strategy. Choices are 'tp' for Tensor Parallel Strategy or 'none'.",
+    )
+    parser.add_argument(
+        "--pt2e_quant",
+        action="store_true",
+        help="Whether to use pt2e kind of quant flow or not.",
+    )
+    parser.add_argument(
+        "--quant_dtype",
+        default='fp8_143',
+        type=str,
+        help="Set pt2e quantization data type. Available options: int8, fp8_143 [default], fp8_152",
+    )
+
+    args = parser.parse_args()
+
+    if args.pt2e_quant:
+        os.environ["USE_PT2E_QUANT"] = "1"
+        args.torch_compile = False
+        args.use_hpu_graphs = False
+        if args.quant_dtype not in ['int8', 'fp8_143', 'fp8_152']:
+            logger.info("Unsupported quantization data type! Using fp8_143 by default.")
+            args.quant_dtype = 'fp8_143'
+        os.environ["USE_PT2E_QUANT_DTYPE"] = args.quant_dtype
+
+    if args.torch_compile:
+        args.use_hpu_graphs = False
+
+    if not args.use_hpu_graphs:
+        args.limit_hpu_graphs = False
+
+    if args.flash_attention_fast_softmax is None:
+        args.flash_attention_fast_softmax = args.use_flash_attention
+
+    args.quant_config = os.getenv("QUANT_CONFIG", "")
+    if args.quant_config and args.gptq:
+        raise RuntimeError("Setting both quant_config and gptq is unsupported. ")
+
+    if args.quant_config == "" and args.disk_offload:
+        logger.warning(
+            "`--disk_offload` was tested only with fp8, it may not work with full precision. If error raises try to remove the --disk_offload flag."
+        )
+    return args
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    args = setup_parser(parser)
+    model, assistant_model, tokenizer, generation_config = initialize_model(args, logger)
+
+    use_lazy_mode = True
+    if args.torch_compile or (args.pt2e_quant and model.config.model_type == "llama"):
+        use_lazy_mode = False
+
+    import habana_frameworks.torch.hpu as torch_hpu
+
+    run_modes = ["pt2e_quant_not_used"]
+    if args.pt2e_quant and model.config.model_type == "llama":
+        run_modes = ["pt2e_quant_calibration", "pt2e_quant_inference"]
+
+    for mode in run_modes:
+        if mode == "pt2e_quant_calibration":
+            logger.info("[pt2e_quant] Running in calibration mode...")
+        elif mode == "pt2e_quant_inference":
+            logger.info("[pt2e_quant] Running with quantized model...")
+
+        if args.dataset_name == "openorca":
+            # Benchmark over the prompts below
+            def get_ds(args):
+                ds = pd.read_pickle(args.dataset)
+                return ds
+
+            def get_input(ds, batch_size):
+                queries = []
+                tok_input = ds["tok_input"].tolist()
+                for start in range(0, len(ds), batch_size):
+                    end = start + batch_size
+                    batch = tok_input[start:end]
+                    input_ids = []
+                    attention_mask = []
+                    for query in batch:
+                        input_ids.append([0] * (args.max_input_tokens - len(query)) + query)
+                        attention_mask.append([0] * (args.max_input_tokens - len(query)) + [1] * len(query))
+                    queries.append(
+                        {
+                            "input_ids": torch.tensor(input_ids, dtype=torch.int32),
+                            "attention_mask": torch.tensor(attention_mask, dtype=torch.int32),
+                        }
+                    )
+                return queries
+
+            ds = get_ds(args)
+            input_sentences = get_input(ds, args.batch_size)
+
+            def generate(input_tokens, size=None, reduce_recompile=False):
+                """Generates sequences from the input sentences and returns them."""
+
+                t0 = time.perf_counter()
+                print(f"Step4+ starting time is {t0*1000}", flush=True)
+                if size is not None:
+                    input_tokens = adjust_batch(input_tokens, size)
+
+                if not reduce_recompile:
+                    # Move inputs to target device(s)
+                    for t in input_tokens:
+                        if torch.is_tensor(input_tokens[t]):
+                            input_tokens[t] = input_tokens[t].to(args.device)
+
+                outputs = model.generate(
+                    **input_tokens,
+                    generation_config=generation_config,
+                    lazy_mode=use_lazy_mode,
+                    hpu_graphs=args.use_hpu_graphs,
+                    profiling_steps=args.profiling_steps,
+                    profiling_warmup_steps=args.profiling_warmup_steps,
+                ).cpu()
+                outputs = outputs.tolist()
+                for i in range(len(outputs)):
+                    outputs[i] = outputs[i][args.max_input_tokens :]
+                duration = time.perf_counter() - t0
+                print(f"Total E2E time of this batch is {duration:.3f}s", flush=True)
+                return outputs
+
+            from optimum.habana.utils import HabanaProfile
+
+            # compilation stage disable profiling
+            HabanaProfile.disable()
+            # Compilation
+            logger.info("Graph compilation...")
+            dyn_prompt_lens = args.simulate_dyn_prompt
+            t0 = time.perf_counter()
+            # The first three iterations take longer because of graph compilation
+            if dyn_prompt_lens is None or len(set(dyn_prompt_lens)) == 1:
+                for _ in range(args.warmup):
+                    if dyn_prompt_lens is None:
+                        print("Warming up", flush=True)
+                        generate(input_sentences[0], None, args.reduce_recompile)
+                    else:
+                        print("Warming up for shape,", dyn_prompt_lens[0], flush=True)
+                        generate(input_sentences[0], dyn_prompt_lens[0], args.reduce_recompile)
+            else:
+                if args.bucket_size > 0:
+                    mn = min(dyn_prompt_lens)
+                    mx = max(dyn_prompt_lens)
+
+                    def rounder(x):
+                        return int(math.ceil(x / args.bucket_size) * args.bucket_size)
+
+                    min_prompt_len = rounder(mn)
+                    max_sentence_len = rounder(mx)
+                    for _ in range(args.warmup):
+                        lst = list(range(min_prompt_len, max_sentence_len + 1, args.bucket_size))
+                        for sz in lst:
+                            print("Warming up for shape,", sz - 1, flush=True)
+                            generate(input_sentences[0], sz - 1, args.reduce_recompile)
+            torch_hpu.synchronize()
+            compilation_duration = time.perf_counter() - t0
+            HabanaProfile.enable()
+            total_new_tokens_generated = 0
+            logger.info("Running generate...")
+            t0 = time.perf_counter()
+            # Benchmark over n_iterations iterations
+            N = len(input_sentences)
+            if dyn_prompt_lens is None:
+                for i in range(args.n_iterations):
+                    results = []
+                    b = 1
+                    for sentence in input_sentences:
+                        generated = generate(sentence, None, args.reduce_recompile)
+                        results.extend(generated)
+                        print(f"Generatig batch {b}/{N}")
+                        b += 1
+            else:
+                repeated_prompt_len = cycle(dyn_prompt_lens)
+                for i in range(args.n_iterations):
+                    prompt_len = next(repeated_prompt_len)
+                    print("Generating for shape,", prompt_len)
+                    results = []
+                    for sentence in input_sentences:
+                        generated = generate(sentence, prompt_len, args.reduce_recompile)
+                        results.extend(generated)
+            duration = time.perf_counter() - t0
+            total_new_tokens_generated = args.n_iterations * args.batch_size * args.max_new_tokens
+            throughput = total_new_tokens_generated / duration
+
+            # Store results if necessary
+            if args.output_dir is not None and args.global_rank == 0:
+                output_dir = Path(args.output_dir)
+                output_dir.mkdir(parents=True, exist_ok=True)
+
+                # TODO dump in hex format
+                acc_file = []
+                num_token = 0
+                for i, idx in enumerate(ds.index):
+                    pred = results[i]
+                    eos_token_id = 2
+                    try:
+                        ind_eos = pred.index(eos_token_id) + 1
+                    except:  # noqa
+                        ind_eos = len(pred)
+                    pred = pred[:ind_eos]
+                    num_token += len(pred)
+                    acc_file.append(
+                        {"seq_id": idx, "qsl_idx": idx, "data": bytes(struct.pack("L" * len(pred), *pred)).hex().upper()}
+                    )
+                with open(output_dir / "accuracy.json", "w") as outfile:
+                    outfile.write(json.dumps(acc_file))
+
+            stats = f"Throughput (including tokenization) = {throughput} tokens/second"
+            stats = stats + f"\nNumber of HPU graphs                = {count_hpu_graphs()}"
+            separator = "-" * len(stats)
+            print()
+            print("Stats:")
+            print(separator)
+            print(stats)
+            mem = get_hpu_memory_stats()
+            for k, v in mem.items():
+                print("{:35} = {} GB".format(k[:-5].replace("_", " ").capitalize(), v))
+            print(f"Graph compilation duration          = {compilation_duration} seconds")
+            print(separator)
+            print()
+        elif args.dataset_name is None:
+            # Benchmark over the prompts below
+            if args.prompt:
+                input_sentences = args.prompt
+            elif args.book_source:
+
+                def download_book(book_id):
+                    import os
+
+                    import requests
+
+                    url = f"https://www.gutenberg.org/cache/epub/{book_id}/pg{book_id}.txt"
+                    response = requests.get(url)
+                    if response.status_code == 200:
+                        pid = os.getpid()
+                        save_path = f"/tmp/{book_id}_{pid}.txt"
+                        with open(save_path, "wb") as file:
+                            file.write(response.content)
+                        print(f"Book downloaded and saved to: {save_path}")
+                        return save_path
+                    else:
+                        print("Failed to download book! Exiting...")
+                        import sys
+
+                        sys.exit()
+
+                def assemble_prompt(prompt_size, book_path):
+                    prompt = ""
+                    counter = 0
+                    book_lines = open(book_path).readlines()
+                    for line in book_lines:
+                        for word in line.split():
+                            counter += 1
+                            prompt += word + " "
+                            if counter == prompt_size:
+                                return [prompt] * args.batch_size
+
+                book_ids = [
+                    2701,  # Moby Dick; Or, The Whale
+                    1513,  # Romeo and Juliet
+                    1342,  # Pride and Prejudice
+                ]
+                input_sentences = assemble_prompt(prompt_size=args.max_input_tokens, book_path=download_book(book_ids[0]))
+            else:
+                input_sentences = [
+                    "DeepSpeed is a machine learning framework",
+                    "He is working on",
+                    "He has a",
+                    "He got all",
+                    "Everyone is happy and I can",
+                    "The new movie that got Oscar this year",
+                    "In the far far distance from our galaxy,",
+                    "Peace is the only way",
+                ]
+
+            if args.batch_size > len(input_sentences):
+                # Dynamically extends to support larger batch sizes
+                num_sentences_to_add = args.batch_size - len(input_sentences)
+                for i in range(num_sentences_to_add):
+                    input_sentences.append(input_sentences[i % len(input_sentences)])
+            elif args.batch_size < len(input_sentences):
+                input_sentences = input_sentences[: args.batch_size]
+
+            def generate(size=None, reduce_recompile=False):
+                """Generates sequences from the input sentences and returns them."""
+                encode_t0 = time.perf_counter()
+                t0 = time.perf_counter()
+                print(f"Step4+ starting time is {t0*1000}", flush=True)
+                # Tokenization
+                if args.max_input_tokens > 0:
+                    input_tokens = tokenizer.batch_encode_plus(
+                        input_sentences,
+                        return_tensors="pt",
+                        padding="max_length",
+                        max_length=args.max_input_tokens,
+                        truncation=True,
+                    )
+                    def compute_valid_sequence_lengths_tensor(input_tokens):
+                        attn_mask = input_tokens['attention_mask']
+                        return torch.sum(attn_mask, dim=1)
+                    valid_sequence_lengths = compute_valid_sequence_lengths_tensor(input_tokens).to(args.device)
+                    generation_config.valid_sequence_lengths = valid_sequence_lengths
+                else:
+                    input_tokens = tokenizer.batch_encode_plus(input_sentences, return_tensors="pt", padding=True)
+                encode_duration = time.perf_counter() - encode_t0
+
+                if size is not None:
+                    input_tokens = adjust_batch(input_tokens, size)
+                if not reduce_recompile:
+                    # Move inputs to target device(s)
+                    for t in input_tokens:
+                        if torch.is_tensor(input_tokens[t]):
+                            input_tokens[t] = input_tokens[t].to(args.device)
+                iteration_times = []
+                output_tokens = model.generate(
+                    **input_tokens,
+                    generation_config=generation_config,
+                    assistant_model=assistant_model,
+                    lazy_mode=use_lazy_mode,
+                    hpu_graphs=args.use_hpu_graphs,
+                    profiling_steps=args.profiling_steps,
+                    profiling_warmup_steps=args.profiling_warmup_steps,
+                    ignore_eos=args.ignore_eos,
+                    iteration_times=iteration_times,
+                    profiling_record_shapes=args.profiling_record_shapes,
+                ).cpu()
+                outputs = tokenizer.batch_decode(output_tokens, skip_special_tokens=True)
+                duration = time.perf_counter() - t0
+                first_token_time = iteration_times[0] + encode_duration
+                logger.info(f"Time to first token = {first_token_time*1000}ms")
+                print(f"Total E2E time of this iteration is {duration:.3f}s", flush=True)
+                return outputs
+
+            from optimum.habana.utils import HabanaProfile
+
+            # compilation stage disable profiling
+            HabanaProfile.disable()
+            # Compilation
+            logger.info("Graph compilation...")
+            dyn_prompt_lens = args.simulate_dyn_prompt
+            t0 = time.perf_counter()
+            # The first three iterations take longer because of graph compilation
+            if dyn_prompt_lens is None or len(set(dyn_prompt_lens)) == 1:
+                for _ in range(args.warmup):
+                    if dyn_prompt_lens is None:
+                        print("Warming up", flush=True)
+                        generate(None, args.reduce_recompile)
+                    else:
+                        print("Warming up for shape,", dyn_prompt_lens[0], flush=True)
+                        generate(dyn_prompt_lens[0], args.reduce_recompile)
+            else:
+                if args.bucket_size > 0:
+                    mn = min(dyn_prompt_lens)
+                    mx = max(dyn_prompt_lens)
+
+                    def rounder(x):
+                        return int(math.ceil(x / args.bucket_size) * args.bucket_size)
+
+                    min_prompt_len = rounder(mn)
+                    max_sentence_len = rounder(mx)
+                    for _ in range(args.warmup):
+                        lst = list(range(min_prompt_len, max_sentence_len + 1, args.bucket_size))
+                        for sz in lst:
+                            print("Warming up for shape,", sz - 1, flush=True)
+                            generate(sz - 1, args.reduce_recompile)
+            torch_hpu.synchronize()
+            compilation_duration = time.perf_counter() - t0
+            HabanaProfile.enable()
+            total_new_tokens_generated = 0
+            logger.info("Running generate...")
+            t0 = time.perf_counter()
+            # Benchmark over n_iterations iterations
+            if dyn_prompt_lens is None:
+                for i in range(args.n_iterations):
+                    generated = generate(None, args.reduce_recompile)
+            else:
+                repeated_prompt_len = cycle(dyn_prompt_lens)
+                for i in range(args.n_iterations):
+                    prompt_len = next(repeated_prompt_len)
+                    print("Generating for shape,", prompt_len)
+                    generated = generate(prompt_len, args.reduce_recompile)
+            duration = time.perf_counter() - t0
+            total_new_tokens_generated = args.n_iterations * args.batch_size * args.max_new_tokens
+            throughput = total_new_tokens_generated / duration
+
+            print()
+            print("Input/outputs:")
+            for i, input_sentence in enumerate(zip(input_sentences)):
+                print(f"input {i+1}: {input_sentence}")
+                for j, output in enumerate(
+                    zip(generated[args.num_return_sequences * i : args.num_return_sequences * (i + 1)])
+                ):
+                    print(f"output {j+1}: {output}")
+                print()
+
+            # Store results if necessary
+            if args.output_dir is not None and args.global_rank == 0:
+                output_dir = Path(args.output_dir)
+                output_dir.mkdir(parents=True, exist_ok=True)
+
+                results = {
+                    "throughput": throughput,
+                    "output": output,
+                }
+                with (output_dir / "results.json").open("w", encoding="utf-8") as f:
+                    json.dump(results, f, ensure_ascii=False, indent=4)
+
+            stats = f"Throughput (including tokenization) = {throughput} tokens/second"
+            stats = stats + f"\nNumber of HPU graphs                = {count_hpu_graphs()}"
+            separator = "-" * len(stats)
+            print()
+            print("Stats:")
+            print(separator)
+            print(stats)
+            mem = get_hpu_memory_stats()
+            for k, v in mem.items():
+                print("{:35} = {} GB".format(k[:-5].replace("_", " ").capitalize(), v))
+            print(f"Graph compilation duration          = {compilation_duration} seconds")
+            print(separator)
+            print()
+        else:
+            # Downloading and loading a dataset from the hub.
+            from datasets import load_dataset
+            from torch.utils.data import DataLoader
+
+            assert not args.simulate_dyn_prompt, "Both dataset_name and simulate_dyn_prompt are set"
+
+            raw_dataset = load_dataset(args.dataset_name)
+            if "test" in raw_dataset:
+                split = "test"
+            elif "validation" in raw_dataset:
+                split = "validation"
+            else:
+                split = "train"
+            raw_dataset = (
+                raw_dataset[split]
+                .shuffle()
+                .select(range(args.dataset_max_samples if args.dataset_max_samples > 0 else (raw_dataset[split]).num_rows))
+            )
+
+            if args.column_name is None:
+                # If no column name is given, take the first column that has strings
+                column_name = [key for key in raw_dataset.features.keys() if raw_dataset.features[key].dtype == "string"][
+                    0
+                ]
+                logger.info(
+                    f"No column name was given so automatically choosing '{column_name}' for prompts. If you would like to use another column of the dataset, you can set the argument `--column_name`."
+                )
+            else:
+                column_name = args.column_name
+
+            # Remove unused columns
+            raw_dataset = raw_dataset.remove_columns([name for name in raw_dataset.column_names if name != column_name])
+
+            # Set the prompt length to args.max_input_tokens if > 0 else (if 0 truncate to 16, otherwise use full length)
+            prompt_length = args.max_input_tokens if args.max_input_tokens > 0 else (-1, 16)[args.max_input_tokens == 0]
+
+            def preprocess_function(examples):
+                # Tokenize the texts
+                return tokenizer(
+                    examples[column_name],
+                    padding="max_length",
+                    max_length=prompt_length if prompt_length > 0 else None,
+                    truncation=prompt_length > 0,
+                )
+
+            raw_dataset = raw_dataset.map(
+                preprocess_function,
+                batched=True,
+                desc="Running tokenizer on dataset",
+            )
+            # After tokenization, we can remove the column of interest
+            raw_dataset = raw_dataset.remove_columns([column_name])
+            raw_dataset.set_format(type="torch")
+
+            if prompt_length <= 0:
+                # Todo please check if this collate function is suitable for your model
+                # This has been tested for OPT, llama, and Bloom
+                assert model.config.model_type in ["opt", "bloom", "llama"]
+
+                def collate_fn(data):
+                    collect = {k: [dt[k] for dt in data] for k in data[0]}
+                    result = {}
+                    for k in collect:
+                        tensors = collect[k]
+                        max_shape = max([item.shape[0] for item in tensors])
+                        result[k] = torch.stack(
+                            [torch.cat((torch.zeros(max_shape - t.shape[0], dtype=t.dtype), t)) for t in tensors], 0
+                        )
+                    return result
+
+            else:
+                collate_fn = None
+
+            dataloader = DataLoader(raw_dataset, batch_size=args.batch_size, collate_fn=collate_fn)
+
+            def generate_dataset(batch):
+                prompt = tokenizer.batch_decode(batch["input_ids"], skip_special_tokens=True)
+                # Move inputs to target device(s)
+                for t in batch:
+                    if torch.is_tensor(batch[t]):
+                        batch[t] = batch[t].to(args.device)
+                # Generate new sequences
+                outputs = model.generate(
+                    **batch,
+                    generation_config=generation_config,
+                    lazy_mode=use_lazy_mode,
+                    hpu_graphs=args.use_hpu_graphs,
+                    profiling_steps=args.profiling_steps,
+                    profiling_warmup_steps=args.profiling_warmup_steps,
+                    ignore_eos=args.ignore_eos,
+                    profiling_record_shapes=args.profiling_record_shapes,
+                ).cpu()
+                return prompt, outputs
+
+            # warmup
+            if prompt_length > 0:
+                from optimum.habana.utils import HabanaProfile
+
+                # compilation stage disable profiling
+                HabanaProfile.disable()
+                # Compilation
+                logger.info("Graph compilation...")
+                t0 = time.perf_counter()
+                for i, batch in enumerate(dataloader):
+                    generate_dataset(batch)
+                    # The first three iterations take longer because of graph compilation
+                    if (i + 1) == 3:
+                        break
+                torch_hpu.synchronize()
+                compilation_duration = time.perf_counter() - t0
+                HabanaProfile.enable()
+
+            total_new_tokens_generated = 0
+            duration = 0
+            separator = "-" * 50
+            logger.info("Running generate dataset...")
+            t_start = time.time()
+            for i, batch in enumerate(dataloader):
+                t0 = time.perf_counter()
+                prompt, outputs = generate_dataset(batch)
+                duration += time.perf_counter() - t0
+                total_new_tokens_generated += args.batch_size * args.max_new_tokens
+                print(separator)
+                print(f"Batch n°{i+1}")
+                print(f"Input: {prompt[:args.batch_size]}")
+                print(
+                    f"Output: {tokenizer.batch_decode(outputs, skip_special_tokens=True)[:args.batch_size*args.num_return_sequences]}"
+                )
+                print(separator)
+                if args.run_partial_dataset and args.n_iterations == i+1:
+                    break
+            t_end = time.time()
+
+            throughput = total_new_tokens_generated / duration
+            # Print Stats
+
+            stats = f"Throughput (including tokenization) = {throughput} tokens/second"
+            separator = "-" * len(stats)
+            print()
+            print("Stats:")
+            print(separator)
+            print(stats)
+            print("Total runtime for dataset:", t_end - t_start)
+            mem = get_hpu_memory_stats()
+            for k, v in mem.items():
+                print("{:35} = {} GB".format(k[:-5].replace("_", " ").capitalize(), v))
+            if prompt_length > 0:
+                print(f"Graph compilation duration          = {compilation_duration} seconds")
+            print(separator)
+
+        if mode == "pt2e_quant_calibration":
+            # Prepare for next run with quantized model
+            from utils import add_quant_dquant_nodes
+            model = add_quant_dquant_nodes(model, logger)
+
+    if args.quant_config:
+        finalize_quantization(model)
+    if args.const_serialization_path and os.path.isdir(args.const_serialization_path):
+        import shutil
+
+        shutil.rmtree(args.const_serialization_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/text-generation/experimental/run_lm_eval.py
+++ b/examples/text-generation/experimental/run_lm_eval.py
@@ -1,0 +1,234 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Copyright (C) 2020-2021 Habana Labs, Ltd. an Intel Company
+###############################################################################
+
+import argparse
+import json
+import logging
+import os
+import time
+
+import lm_eval.evaluator
+import lm_eval.tasks
+import torch
+import torch.nn.functional as F
+from run_generation import setup_parser
+from utils import finalize_quantization, initialize_model
+
+from optimum.habana.utils import get_hpu_memory_stats
+
+
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+os.environ.setdefault("HF_DATASETS_TRUST_REMOTE_CODE", "true")
+logger = logging.getLogger(__name__)
+
+import multiprocessing as mp
+import psutil
+
+# This hack is a workaround to limitations of lm_eval which always allocates
+# mp.Pool with max cpu count which explodes on multinode scenarios and for hpu
+# create multiprocess with spawn context
+OrigPool = mp.Pool
+def LimitedSpawnPool(_):
+    spawn_context = mp.get_context("spawn")
+    physical_cpu_count = psutil.cpu_count(logical=False)
+    pool_size = physical_cpu_count
+    world_size = int(os.getenv("WORLD_SIZE", 1))
+    if world_size == 0:
+        world_size = 1
+    pool_size //= world_size
+    if (pool_size * world_size) != physical_cpu_count:
+        pool_size -= 1
+    return spawn_context.Pool(pool_size)
+mp.Pool = LimitedSpawnPool
+
+
+def setup_lm_eval_parser():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter, description="Evaluation script for HPU"
+    )
+    parser.add_argument(
+        "--buckets",
+        type=int,
+        nargs="+",
+        help="Input length buckets to use with static_shapes",
+        default=[16, 32, 64, 128, 189, 284],
+    )
+
+    parser.add_argument(
+        "--output_file", "-o", type=str, help="Output file with end results and runtime parameters", required=True
+    )
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        nargs="+",
+        help="Tasks to run",
+        default=["hellaswag", "lambada_openai", "piqa", "winogrande"],
+    )
+    parser.add_argument("--limit_iters", type=int, help="limit examples to run that many iterations", default=None)
+    args = setup_parser(parser)
+
+    return args
+
+
+class HabanaModelAdapter(lm_eval.base.BaseLM):
+    def __init__(self, tokenizer, model, args, options):
+        super().__init__()
+        self.tokenizer = tokenizer
+        self.model = model
+        self._batch_size = args.batch_size
+        self.buckets = sorted(args.buckets)
+        self.options = options
+        self._device = args.device
+        self.model_inputs = {"use_cache": self.options.use_cache}
+        if self.model.config.model_type in ["llama", "mistral", "falcon", "phi", "mixtral", "qwen2"]:
+            self.model_inputs.update(
+                {
+                    "reuse_cache": self.options.reuse_cache,
+                }
+            )
+        if self.model.config.model_type in ["llama", "mistral", "qwen2", "falcon"]:
+            if self.model.config.model_type != "falcon":
+                self.model_inputs.update(
+                    {
+                        "attn_softmax_bf16": self.options.attn_softmax_bf16,
+                    }
+                )
+            self.model_inputs.update(
+                {
+                    "use_flash_attention": self.options.use_flash_attention,
+                    "flash_attention_recompute": self.options.flash_attention_recompute,
+                    "flash_attention_causal_mask": self.options.flash_attention_causal_mask,
+                }
+            )
+        if args.warmup:
+            self.warm_up()
+
+    def warm_up(self):
+        for bucket_size in reversed(self.buckets):
+            inps = torch.ones((self._batch_size, bucket_size), dtype=torch.int64)
+            self._model_call(inps)
+            pass
+
+    @property
+    def eot_token_id(self):
+        return self.model.config.eos_token_id
+
+    @property
+    def max_length(self):
+        return self.buckets[-1]
+
+    @property
+    def max_gen_toks(self):
+        raise NotImplementedError()
+
+    @property
+    def batch_size(self):
+        return self._batch_size
+
+    @property
+    def device(self):
+        # We need to do padding ourselves, otherwise we'll end up with recompilations
+        # Returning 'cpu' to keep tensors on CPU in lm_eval code
+        return "cpu"
+
+    def tok_encode(self, string):
+        return self.tokenizer.encode(string)
+
+    def tok_decode(self, tokens):
+        return self.tokenizer.decode(tokens)
+
+    def _model_generate(self, context, max_length, eos_token_id):
+        raise NotImplementedError()
+
+    def find_bucket(self, length):
+        return [b for b in self.buckets if b >= length][0]
+
+    def _model_call(self, inps):
+        bs, seq_length = inps.shape
+        padding_length = 0
+        if self.options.static_shapes:
+            bucket_length = self.find_bucket(seq_length)
+            if self.options.use_cache and self.options.reuse_cache:
+                self.model.allocate_kv_cache(bs, bucket_length + 1, bucket_length)
+            padding_length = bucket_length - seq_length
+            inps = F.pad(inps, (0, padding_length), value=self.model.config.pad_token_id)
+        logits = self.model(inps.to(self._device), **self.model_inputs)["logits"].cpu()
+
+        if self.options.static_shapes and padding_length > 0:
+            logits = logits[:, :-padding_length, :]
+        logits = logits.to(torch.float32)
+        return logits
+
+
+def main():
+    args = setup_lm_eval_parser()
+    model, _, tokenizer, generation_config = initialize_model(args, logger)
+
+    lm_tasks = lm_eval.tasks.get_task_dict(args.tasks)
+
+    run_modes = ["pt2e_quant_not_used"]
+    if args.pt2e_quant and model.config.model_type == "llama":
+        run_modes = ["pt2e_quant_calibration", "pt2e_quant_inference"]
+
+    for mode in run_modes:
+        if mode == "pt2e_quant_calibration":
+            logger.info("[pt2e_quant] Running in calibration mode...")
+        elif mode == "pt2e_quant_inference":
+            logger.info("[pt2e_quant] Running with quantized model...")
+
+        with torch.no_grad():
+            lm = HabanaModelAdapter(tokenizer, model, args, generation_config)
+
+        eval_start = time.perf_counter()
+        results = {}
+        with torch.no_grad():
+            results = lm_eval.evaluator.evaluate(lm, lm_tasks, limit=args.limit_iters)
+        if args.device == "hpu":
+            import habana_frameworks.torch.hpu as torch_hpu
+
+            torch_hpu.synchronize()
+        eval_end = time.perf_counter()
+
+        results["args"] = vars(args)
+        results["duration"] = eval_end - eval_start
+
+        if args.local_rank == 0:
+            if args.device == "hpu":
+                mem = get_hpu_memory_stats()
+                for k, v in mem.items():
+                    print("{:35} = {} GB".format(k[:-5].replace("_", " ").capitalize(), v))
+            json.dump(results, open(args.output_file, "w"), indent=2)
+            print(json.dumps(results, indent=2))
+
+        if mode == "pt2e_quant_calibration":
+            # Prepare for next run with quantized model
+            from utils import add_quant_dquant_nodes
+            model = add_quant_dquant_nodes(model, logger)
+
+    if args.quant_config:
+        finalize_quantization(model)
+
+    if args.const_serialization_path and os.path.isdir(args.const_serialization_path):
+        import shutil
+
+        shutil.rmtree(args.const_serialization_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/text-generation/utils.py
+++ b/examples/text-generation/utils.py
@@ -43,6 +43,16 @@ from optimum.habana.utils import (
     set_seed,
 )
 
+from habana_frameworks.torch.core.quantize_pt2e import (
+    export,
+    convert_pt2e,
+    prepare_pt2e,
+)
+
+from habana_frameworks.torch.core.quantizer import (
+    habana_quantizer,
+    habana_quant_config_symmetric,
+)
 
 def adjust_batch(batch, size):
     curr_size = batch["input_ids"].shape[1]
@@ -213,6 +223,34 @@ def finalize_quantization(model):
         habana_quantization_toolkit.finish_measurements(model)
 
 
+# [Experimental] export and prepare_pt2e
+def get_model_with_observer(args, model, logger):
+    logger.info("[pt2e_quant] Inserting observers for measurement.")
+
+    QUANTIZER_DTYPES = {'int8': torch.int8, 'fp8_143': torch.float8_e4m3fn, 'fp8_152': torch.float8_e5m2}
+    quant_dtype = QUANTIZER_DTYPES[os.getenv("USE_PT2E_QUANT_DTYPE", "fp8_143")]
+
+    quantizer = habana_quantizer()
+    quant_config = habana_quant_config_symmetric(quant_dtype)
+    quantizer.set_global(quant_config)
+
+    actual_model = model.model
+    exported_model, _ = export(actual_model)
+
+    prepared_model = prepare_pt2e(exported_model, quantizer)
+    model.model = prepared_model
+
+    return model
+
+
+# [Experimental] convert_pt2e
+def add_quant_dquant_nodes(model, logger):
+    logger.info("[pt2e_quant] Converting model after calibration.")
+
+    model.model = convert_pt2e(model.model)
+    return model
+
+
 def setup_model(args, model_dtype, model_kwargs, logger):
     logger.info("Single-device run.")
     if args.assistant_model is None:
@@ -291,6 +329,12 @@ def setup_model(args, model_dtype, model_kwargs, logger):
         model = get_torch_compiled_model(model)
         # if args.assistant_model is not None:
         #     assistant_model = get_torch_compiled_model(assistant_model)
+
+    # [Experimental] PT2E Quant like flow
+    if os.getenv("USE_PT2E_QUANT", "0") == "1" and model.config.model_type == "llama":
+        logger.info("[pt2e_quant] Using PT2 Export like flow for measurement / quantization.")
+        model = get_model_with_observer(args, model, logger)
+
     return model, assistant_model
 
 
@@ -436,6 +480,12 @@ def setup_distributed_model(args, model_dtype, model_kwargs, logger):
         model = get_torch_compiled_model(model)
         # if args.assistant_model is not None:
         #     assistant_model = get_torch_compiled_model(assistant_model)
+
+    # [Experimental] PT2E Quant like flow
+    if os.getenv("USE_PT2E_QUANT", "0") == "1" and model.config.model_type == "llama":
+        logger.info("[pt2e_quant] Using PT2 Export like flow for measurement / quantization.")
+        model = get_model_with_observer(args, model, logger)
+
     return model, assistant_model
 
 


### PR DESCRIPTION
This is an experimental change to test Habana's PT2E-quantization flow with LLM, such as Llama2.

Motivation:
PT2-Export based quantization workflow in Pytorch captures the model into a graph and performs quantization transformations on top of the ATen dialect graph. This approach is claimed to have higher model coverage as compared to earlier FX Graph Mode Quantization approach, better programmability, and a simplified UX. But, PT2-Export has limitation that the model must be serialized (without any graph breaks, e.g. no data dependent conditional flow etc.). As a result, very first stage of PT2E quantization flow fails for autoregressive models like Bloom, GPTJ, Llama2. Habana has come up with a promising solution to overcome the above-mentioned problem.

This change includes modifications / additions on existing optimum-habana scripts to test Habana's solution with LLM, such as Llama2.
