### PR TITLE
Simplify HQT config - Configure default behaviour as empty 'allowlist'/'blocklist' configuration 

### DIFF
--- a/examples/text-generation/quantization_config/act_maxabs_pow2_weights_pcs_opt_pow2_quant.json
+++ b/examples/text-generation/quantization_config/act_maxabs_pow2_weights_pcs_opt_pow2_quant.json
@@ -3,7 +3,5 @@
     "mode": "QUANTIZE",
     "observer": "maxabs",
     "scale_method": "ACT_MAXABS_POW2_WEIGHTS_PCS_OPT_POW2",
-    "allowlist": {"types": [], "names":  []},
-    "blocklist": {"types": [], "names":  []},
     "dump_stats_path": "./hqt_output/measure"
 }

--- a/examples/text-generation/quantization_config/maxabs_measure.json
+++ b/examples/text-generation/quantization_config/maxabs_measure.json
@@ -2,8 +2,6 @@
     "method": "HOOKS",
     "mode": "MEASURE",
     "observer": "maxabs",
-    "allowlist": {"types": [], "names":  []},
-    "blocklist": {"types": [], "names":  []},
     "dump_stats_path": "./hqt_output/measure",
     "dump_stats_xlsx_path": "./hqt_output/measure/fp8stats.xlsx"
 }

--- a/examples/text-generation/quantization_config/maxabs_measure.json
+++ b/examples/text-generation/quantization_config/maxabs_measure.json
@@ -3,5 +3,4 @@
     "mode": "MEASURE",
     "observer": "maxabs",
     "dump_stats_path": "./hqt_output/measure",
-    "dump_stats_xlsx_path": "./hqt_output/measure/fp8stats.xlsx"
 }

--- a/examples/text-generation/quantization_config/maxabs_measure_include_outputs.json
+++ b/examples/text-generation/quantization_config/maxabs_measure_include_outputs.json
@@ -3,7 +3,5 @@
     "mode": "MEASURE",
     "observer": "maxabs",
     "measure_exclude": "NONE",
-    "allowlist": {"types": [], "names":  []},
-    "blocklist": {"types": [], "names":  []},
     "dump_stats_path": "./hqt_output/measure"
 }

--- a/examples/text-generation/quantization_config/maxabs_quant.json
+++ b/examples/text-generation/quantization_config/maxabs_quant.json
@@ -3,7 +3,5 @@
     "mode": "QUANTIZE",
     "observer": "maxabs",
     "scale_method": "maxabs_hw",
-    "allowlist": {"types": [], "names":  []},
-    "blocklist": {"types": [], "names":  []},
     "dump_stats_path": "./hqt_output/measure"
 }

--- a/examples/text-generation/quantization_config/maxabs_quant_phi.json
+++ b/examples/text-generation/quantization_config/maxabs_quant_phi.json
@@ -3,7 +3,6 @@
     "mode": "QUANTIZE",
     "observer": "maxabs",
     "scale_method": "maxabs_hw",
-    "allowlist": {"types": [], "names":  []},
     "blocklist": {"types": [], "names":  [
         "matmul_qk",
         "matmul_av",

--- a/examples/text-generation/quantization_config/unit_scale_quant.json
+++ b/examples/text-generation/quantization_config/unit_scale_quant.json
@@ -3,7 +3,5 @@
     "mode": "QUANTIZE",
     "observer": "maxabs",
     "scale_method": "unit_scale",
-    "allowlist": {"types": [], "names":  []},
-    "blocklist": {"types": [], "names":  []},
     "dump_stats_path": "./hqt_output/measure"
 }


### PR DESCRIPTION
Remove unnecessary 'allowlist'/'blocklist' configurations as the default configuration is now identical to configuring empty lists

