### PR TITLE
Add check for vsl attribute in GaudiGenerationMixin

### DIFF
--- a/optimum/habana/transformers/generation/utils.py
+++ b/optimum/habana/transformers/generation/utils.py
@@ -1000,7 +1000,10 @@ class GaudiGenerationMixin(GenerationMixin):
         )
         model_kwargs["num_virtual_tokens"] = num_virtual_tokens
 
-        model_kwargs["valid_sequence_lengths"] = generation_config.valid_sequence_lengths
+        if hasattr(generation_config, "valid_sequence_lengths"):
+            model_kwargs["valid_sequence_lengths"] = generation_config.valid_sequence_lengths
+        else:
+            model_kwargs["valid_sequence_lengths"] = None
         if not self.config.is_encoder_decoder:
             calculated_max_length = input_ids.shape[-1] + num_virtual_tokens
             if not generation_config.static_shapes and generation_config.max_new_tokens is not None:


### PR DESCRIPTION
This PR adds check for existance of valid_sequence_lengths attribute on generation config. Necessary for the cases where setup_generation_config is not called and thus valid_sequence_lengths doesn't exists.