### PR TITLE
[SW-192950] Prevent graph breaks in Llama

### DIFF
--- a/optimum/habana/accelerate/utils/transformer_engine.py
+++ b/optimum/habana/accelerate/utils/transformer_engine.py
@@ -78,13 +78,21 @@ def _convert_model(model, to_transformer_engine=True, _convert_linear=True):
 
             setattr(model, name, new_module)
         elif isinstance(module, ModuleFusedSDPA) and module.flash_attention_fp8 and to_transformer_engine:
-            from habana_frameworks.torch.hpex.experimental.transformer_engine import FusedAttention as te_FusedAttention
-            module._hpu_kernel_fsdpa = te_FusedAttention(
-                scale=module.scale,
-                attention_dropout=module.attention_dropout,
-                enable_recompute=module.enable_recompute,
-            )
-            setattr(model, name, module)
+            from habana_frameworks.torch.hpex.experimental.transformer_engine import FusedAttention as TE_FusedAttention
+
+            class TE_ModuleFusedSDPA(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self._hpu_kernel_fsdpa = TE_FusedAttention(
+                        scale=module.scale,
+                        attention_dropout=module.attention_dropout,
+                        enable_recompute=module.enable_recompute,
+                    )
+
+                def forward(self, query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode, recompute_mode, valid_sequence_lengths, padding_side="left"):
+                    return self._hpu_kernel_fsdpa(query, key, value, attn_mask, is_causal, softmax_mode)
+
+            setattr(model, name, TE_ModuleFusedSDPA())
         else:
             _convert_model(module, to_transformer_engine=to_transformer_engine, _convert_linear=_convert_linear)
 

--- a/optimum/habana/transformers/models/llama/modeling_llama.py
+++ b/optimum/habana/transformers/models/llama/modeling_llama.py
@@ -275,11 +275,7 @@ class ModuleFusedSDPA(torch.nn.Module):
         self.flash_attention_fp8 = flash_attention_fp8
 
     def forward(self, query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode, recompute_mode, valid_sequence_lengths, padding_side="left"):
-        from habana_frameworks.torch.hpex.experimental.transformer_engine import FusedAttention as FusedAttentionTE
-        if isinstance(self._hpu_kernel_fsdpa, FusedAttentionTE):
-            return self._hpu_kernel_fsdpa(query, key, value, attn_mask, is_causal, softmax_mode)
-        else:
-            return self._hpu_kernel_fsdpa.apply(query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode, recompute_mode, valid_sequence_lengths, padding_side)
+        return self._hpu_kernel_fsdpa.apply(query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode, recompute_mode, valid_sequence_lengths, padding_side)
 
 
 class Matmul(torch.nn.Module):


### PR DESCRIPTION
In Llama the FSDPA implementation for FP8 caused graph breaks.
Instead of checking (isinstance) the FSDPA type inside the forward
function of the ModuleFusedSDPA module, the convert_model function
now replaces the whole class.