### PR TITLE
Add Support for Qwen3 Lora 16K DPO

### DIFF
--- a/examples/trl/sft.py
+++ b/examples/trl/sft.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
             train_data = dataset["train"]
             valid_data = dataset["test"]
             logger.info(f"Size of the train set: {len(train_data)}. Size of the validation set: {len(valid_data)}")
-        if args.dataset_name == "lvwerra/stack-exchange-paired":
+        if args.dataset_name == "/data/stack-exchange-paired":
             chars_per_token = chars_token_ratio(train_data, tokenizer)
             logger.info(f"The character to token ratio of the dataset is: {chars_per_token:.2f}")
             formating_func = prepare_sample_text

--- a/optimum/habana/transformers/trainer.py
+++ b/optimum/habana/transformers/trainer.py
@@ -162,7 +162,16 @@ def _get_input_update_settings(model, lazy_mode: Optional[bool] = None) -> tuple
     inputs_update: dict = {}
 
     should_update_inputs = (getattr(model, "generation_config", None) is not None) and (
-        model.config.model_type in ("llama", "qwen2", "starcoder2", "gemma", "baichuan", "chatglm", "deepseek_v2")
+        model.config.model_type in ("llama",
+                                    "qwen2",
+                                    "starcoder2",
+                                    "gemma",
+                                    "baichuan",
+                                    "chatglm",
+                                    "deepseek_v2",
+                                    "qwen2_moe",
+                                    "qwen3",
+                                    "qwen3_moe")
     )
     if should_update_inputs:
         if model.generation_config.attn_softmax_bf16:
@@ -176,7 +185,13 @@ def _get_input_update_settings(model, lazy_mode: Optional[bool] = None) -> tuple
 
     should_update_inputs = (
         (getattr(model, "generation_config", None) is not None)
-        and (model.config.model_type in ("llama", "qwen2", "starcoder2", "mistral"))
+        and (model.config.model_type in ("llama",
+                                         "qwen2",
+                                         "starcoder2",
+                                         "mistral",
+                                         "qwen2_moe",
+                                         "qwen3",
+                                         "qwen3_moe"))
         and (lazy_mode is not None)
     )
     if should_update_inputs:


### PR DESCRIPTION
1.Add flash_attention support to qwen2/3 models
2.Split sequence into tiles when call lm_head to reduce memory usage for long seq.
3.Enable dpo and sft finetune scripts for qwen2/3 models