### PR TITLE
Replace Wan2.2 standalone repo with optimum-habana-fork 

### DIFF
--- a/examples/InfiniteTalk/opea_text2video/Dockerfile-animate
+++ b/examples/InfiniteTalk/opea_text2video/Dockerfile-animate
@@ -11,20 +11,20 @@ RUN useradd -m -s /bin/bash user && \
 COPY src /home/user/text2video
 
 RUN apt update && apt install -y ffmpeg
-RUN cd /home/user && git clone https://github.com/wenbinc-Bin/Wan2.2.git -b hpu
+RUN cd /home/user && git clone https://github.com/HabanaAI/optimum-habana-fork.git -b aice/v1.22.0
 RUN cd /home/user && git clone https://github.com/opea-project/GenAIComps.git
 RUN chown -R user /home/user/text2video
 
 # Set environment variables
 ENV LANG=en_US.UTF-8
-ENV PYTHONPATH=/home/user/text2video:/usr/lib/habanalabs/:/home/user/Wan2.2/:/home/user/GenAIComps/
+ENV PYTHONPATH=/home/user/text2video:/usr/lib/habanalabs/:/home/user/optimum-habana-fork/examples/Wan2.2/:/home/user/GenAIComps/
 
 ARG uvpip='uv pip install --system --no-cache-dir'
 RUN pip install --no-cache-dir --upgrade pip setuptools uv && \
     $uvpip -r /home/user/text2video/requirements.txt && \
-    $uvpip -r /home/user/Wan2.2/requirements.txt && \
-    $uvpip -r /home/user/Wan2.2/requirements_s2v.txt && \
-    pip install -r /home/user/Wan2.2/requirements_animate.txt
+    $uvpip -r /home/user/optimum-habana-fork/examples/Wan2.2/requirements.txt && \
+    $uvpip -r /home/user/optimum-habana-fork/examples/Wan2.2/requirements_s2v.txt && \
+    pip install -r /home/user/optimum-habana-fork/examples/Wan2.2/requirements_animate.txt
 
 USER user
 WORKDIR /home/user/text2video

--- a/examples/InfiniteTalk/opea_text2video/Dockerfile-wan
+++ b/examples/InfiniteTalk/opea_text2video/Dockerfile-wan
@@ -11,20 +11,20 @@ RUN useradd -m -s /bin/bash user && \
 COPY src /home/user/text2video
 
 RUN apt update && apt install -y ffmpeg
-RUN cd /home/user && git clone https://github.com/wenbinc-Bin/Wan2.2.git -b hpu
+RUN cd /home/user && git clone https://github.com/HabanaAI/optimum-habana-fork.git -b aice/v1.22.0
 RUN cd /home/user && git clone https://github.com/opea-project/GenAIComps.git
 RUN chown -R user /home/user/text2video
 
 # Set environment variables
 ENV LANG=en_US.UTF-8
-ENV PYTHONPATH=/home/user/text2video:/usr/lib/habanalabs/:/home/user/Wan2.2/:/home/user/GenAIComps/
+ENV PYTHONPATH=/home/user/text2video:/usr/lib/habanalabs/:/home/user/optimum-habana-fork/examples/Wan2.2/:/home/user/GenAIComps/
 
 ARG uvpip='uv pip install --system --no-cache-dir'
 RUN pip install --no-cache-dir --upgrade pip setuptools uv && \
     $uvpip -r /home/user/text2video/requirements.txt && \
-    $uvpip -r /home/user/Wan2.2/requirements.txt && \
-    $uvpip -r /home/user/Wan2.2/requirements_s2v.txt && \
-    pip install -r /home/user/Wan2.2/requirements_animate.txt 
+    $uvpip -r /home/user/optimum-habana-fork/examples/Wan2.2/requirements.txt && \
+    $uvpip -r /home/user/optimum-habana-fork/examples/Wan2.2/requirements_s2v.txt && \
+    pip install -r /home/user/optimum-habana-fork/examples/Wan2.2/requirements_animate.txt
 
 USER user
 WORKDIR /home/user/text2video

--- a/examples/InfiniteTalk/opea_text2video/README_animate.md
+++ b/examples/InfiniteTalk/opea_text2video/README_animate.md
@@ -6,6 +6,8 @@ OPEA Wan Animate (角色动画) 微服务，用于根据参考图像和驱动视
 
 本项目提供 OPEA Wan Animate 组件的独立部署方案。它通过 REST API 提供先进的角色动画生成能力，支持将参考图像中的角色按照驱动视频的动作进行动画化，或替换驱动视频中的角色。本服务针对英特尔 ® Habana® Gaudi® 加速器进行了优化。
 
+> **注意:** Wan2.2 代码已合并到 [optimum-habana-fork](https://github.com/HabanaAI/optimum-habana-fork.git) 仓库的 `examples/Wan2.2` 目录中（分支 `aice/v1.22.0`），无需再单独克隆 Wan2.2 仓库。
+
 ## 主要特性
 
 - **角色动画 (Animate)**: 将参考图像中的角色按照驱动视频的动作进行动画化。

--- a/examples/InfiniteTalk/opea_text2video/README_wan.md
+++ b/examples/InfiniteTalk/opea_text2video/README_wan.md
@@ -6,6 +6,8 @@ OPEA Text-to-Video (文本到视频) 微服务，用于根据文本提示和音�
 
 本项目提供 OPEA Text2Video 组件的独立部署方案。它通过 REST API 提供先进的视频生成能力，并针对英特尔 ® Habana® Gaudi® 加速器进行了优化。本指南提供了基于 docker compose 的自动部署和命令行的手工部署两种部署方式。
 
+> **注意:** Wan2.2 代码已合并到 [optimum-habana-fork](https://github.com/HabanaAI/optimum-habana-fork.git) 仓库的 `examples/Wan2.2` 目录中（分支 `aice/v1.22.0`），无需再单独克隆 Wan2.2 仓库。
+
 ## 主要特性
 
 - **文生视频**: 支持文本提示和音频条件输入，生成动态视频。

--- a/examples/InfiniteTalk/opea_text2video/docker-compose-animate.yml
+++ b/examples/InfiniteTalk/opea_text2video/docker-compose-animate.yml
@@ -22,7 +22,7 @@ services:
       - MODEL=Wan2.2-Animate-14B
       - VIDEO_DIR=/home/user/video
       - ANIMATE_COMPONENT_NAME=OPEA_ANIMATE
-      - WAN_ROOT=/home/user/Wan2.2
+      - WAN_ROOT=/home/user/optimum-habana-fork/examples/Wan2.2
 
       - HABANA_VISIBLE_DEVICES=all
       - OMPI_MCA_btl_vader_single_copy_mechanism=none
@@ -65,6 +65,7 @@ services:
         
           exit 0
         '
+
 
       interval: 60s
       timeout: 15s

--- a/examples/InfiniteTalk/opea_text2video/src/job_service_preprocess.py
+++ b/examples/InfiniteTalk/opea_text2video/src/job_service_preprocess.py
@@ -200,7 +200,7 @@ def init_process_pipeline(args):
         ProcessPipeline instance
     """
     # Import preprocessing modules from Wan2.2
-    wan_root = os.getenv("WAN_ROOT", "/home/user/Wan2.2")
+    wan_root = os.getenv("WAN_ROOT", "/home/user/optimum-habana-fork/examples/Wan2.2")
     preprocess_path = os.path.join(wan_root, "wan/modules/animate/preprocess")
     if preprocess_path not in sys.path:
         sys.path.insert(0, preprocess_path)


### PR DESCRIPTION
Wan2.2 code has been merged into optimum-habana-fork under Wan2.2. This PR updates all references in the opea_text2video service to use the integrated Wan2.2 instead of cloning from the standalone wenbinc-Bin/Wan2.2 repository.