### PR TITLE
Add cache_dit  support to GaudiWanPipeline

### DIFF
--- a/examples/stable-diffusion/requirements.txt
+++ b/examples/stable-diffusion/requirements.txt
@@ -4,3 +4,4 @@ sentencepiece
 peft == 0.17.0
 kolors @ git+https://github.com/Kwai-Kolors/Kolors.git
 ftfy
+cache-dit >= 1.1.9

--- a/examples/stable-diffusion/requirements.txt
+++ b/examples/stable-diffusion/requirements.txt
@@ -4,4 +4,4 @@ sentencepiece
 peft == 0.17.0
 kolors @ git+https://github.com/Kwai-Kolors/Kolors.git
 ftfy
-cache-dit >= 1.1.9
+cache-dit == 1.1.9

--- a/examples/stable-diffusion/text_to_video_generation.py
+++ b/examples/stable-diffusion/text_to_video_generation.py
@@ -155,6 +155,57 @@ def main():
 
     parser.add_argument("--seed", type=int, default=42, help="Random seed for initialization.")
 
+    # cache_dit (DBCache) block-caching arguments (Wan pipeline only)
+    parser.add_argument(
+        "--use_cache_dit",
+        action="store_true",
+        help="Enable cache_dit (DBCache) block-level caching to accelerate inference (wan pipeline only).",
+    )
+    parser.add_argument(
+        "--cache_threshold",
+        type=float,
+        default=0.24,
+        help="cache_dit residual_diff_threshold (higher caches more: faster, lower fidelity).",
+    )
+    parser.add_argument(
+        "--cache_warmup",
+        type=int,
+        default=8,
+        help="cache_dit global max_warmup_steps (initial steps always computed).",
+    )
+    parser.add_argument(
+        "--cache_fn_blocks",
+        type=int,
+        default=1,
+        help="cache_dit Fn_compute_blocks (leading transformer blocks always computed).",
+    )
+    parser.add_argument(
+        "--cache_warmup_per_transformer",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Per-transformer warmup steps for Wan2.2 [high_noise, low_noise], e.g. 4 2. "
+        "Overrides --cache_warmup via a per-transformer ParamsModifier.",
+    )
+    parser.add_argument(
+        "--cache_threshold_per_transformer",
+        type=float,
+        nargs="+",
+        default=None,
+        help="Per-transformer thresholds aligned to --cache_warmup_per_transformer, e.g. 0.24 0.24.",
+    )
+    parser.add_argument(
+        "--no_taylorseer",
+        action="store_true",
+        help="Disable the cache_dit TaylorSeer calibrator (enabled by default).",
+    )
+    parser.add_argument(
+        "--taylorseer_order",
+        type=int,
+        default=1,
+        help="cache_dit TaylorSeer expansion order.",
+    )
+
     # HPU-specific arguments
     parser.add_argument("--use_habana", action="store_true", help="Use HPU.")
     parser.add_argument(
@@ -225,6 +276,16 @@ def main():
         pipeline.vae.enable_slicing()
     elif args.pipeline_type == "wan":
         pipeline: GaudiWanPipeline = GaudiWanPipeline.from_pretrained(args.model_name_or_path, **kwargs)
+        if args.use_cache_dit:
+            pipeline.enable_cache_dit(
+                residual_diff_threshold=args.cache_threshold,
+                max_warmup_steps=args.cache_warmup,
+                Fn_compute_blocks=args.cache_fn_blocks,
+                use_taylorseer=not args.no_taylorseer,
+                taylorseer_order=args.taylorseer_order,
+                warmup_steps_per_transformer=args.cache_warmup_per_transformer,
+                thresholds_per_transformer=args.cache_threshold_per_transformer,
+            )
     else:
         logger.error(f"unsupported pipeline type {args.pipeline_type}")
         return None

--- a/examples/stable-diffusion/text_to_video_generation.py
+++ b/examples/stable-diffusion/text_to_video_generation.py
@@ -164,7 +164,7 @@ def main():
     parser.add_argument(
         "--cache_threshold",
         type=float,
-        default=0.24,
+        default=0.15,
         help="cache_dit residual_diff_threshold (higher caches more: faster, lower fidelity).",
     )
     parser.add_argument(

--- a/examples/stable-diffusion/wan_i2v_quantization.py
+++ b/examples/stable-diffusion/wan_i2v_quantization.py
@@ -175,6 +175,57 @@ def main():
 
     parser.add_argument("--seed", type=int, default=42, help="Random seed for initialization.")
 
+    # cache_dit (DBCache) block-caching arguments
+    parser.add_argument(
+        "--use_cache_dit",
+        action="store_true",
+        help="Enable cache_dit (DBCache) block-level caching to accelerate inference.",
+    )
+    parser.add_argument(
+        "--cache_threshold",
+        type=float,
+        default=0.15,
+        help="cache_dit residual_diff_threshold (higher caches more: faster, lower fidelity).",
+    )
+    parser.add_argument(
+        "--cache_warmup",
+        type=int,
+        default=8,
+        help="cache_dit global max_warmup_steps (initial steps always computed).",
+    )
+    parser.add_argument(
+        "--cache_fn_blocks",
+        type=int,
+        default=1,
+        help="cache_dit Fn_compute_blocks (leading transformer blocks always computed).",
+    )
+    parser.add_argument(
+        "--cache_warmup_per_transformer",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Per-transformer warmup steps for Wan2.2 [high_noise, low_noise], e.g. 4 2. "
+        "Overrides --cache_warmup via a per-transformer ParamsModifier.",
+    )
+    parser.add_argument(
+        "--cache_threshold_per_transformer",
+        type=float,
+        nargs="+",
+        default=None,
+        help="Per-transformer thresholds aligned to --cache_warmup_per_transformer, e.g. 0.24 0.24.",
+    )
+    parser.add_argument(
+        "--no_taylorseer",
+        action="store_true",
+        help="Disable the cache_dit TaylorSeer calibrator (enabled by default).",
+    )
+    parser.add_argument(
+        "--taylorseer_order",
+        type=int,
+        default=1,
+        help="cache_dit TaylorSeer expansion order.",
+    )
+
     # HPU-specific arguments
     parser.add_argument("--use_habana", action="store_true", help="Use HPU.")
     parser.add_argument(
@@ -229,7 +280,8 @@ def main():
 
     kwargs = {
         "use_habana": args.use_habana,
-        "use_hpu_graphs": args.use_hpu_graphs,
+        # cache_dit hooks eager block forwards and is incompatible with HPU graphs; force eager when caching.
+        "use_hpu_graphs": False if args.use_cache_dit else args.use_hpu_graphs,
         "gaudi_config": gaudi_config,
     }
     if args.dtype == "bf16":
@@ -258,6 +310,19 @@ def main():
                 pipeline.transformer = prepare(pipeline.transformer, config)
             elif config.quantize:
                 pipeline.transformer = convert(pipeline.transformer, config)
+
+    # Enable cache_dit (DBCache) block caching after any FP8 convert. The two acceleration axes
+    # (FP8 quant + cache_dit) are orthogonal and compound.
+    if args.use_cache_dit:
+        pipeline.enable_cache_dit(
+            residual_diff_threshold=args.cache_threshold,
+            max_warmup_steps=args.cache_warmup,
+            Fn_compute_blocks=args.cache_fn_blocks,
+            use_taylorseer=not args.no_taylorseer,
+            taylorseer_order=args.taylorseer_order,
+            warmup_steps_per_transformer=args.cache_warmup_per_transformer,
+            thresholds_per_transformer=args.cache_threshold_per_transformer,
+        )
 
     set_seed(args.seed)
     max_area = args.max_area

--- a/examples/stable-diffusion/wan_i2v_quantization.py
+++ b/examples/stable-diffusion/wan_i2v_quantization.py
@@ -203,9 +203,10 @@ def main():
         "--cache_warmup_per_transformer",
         type=int,
         nargs="+",
-        default=None,
-        help="Per-transformer warmup steps for Wan2.2 [high_noise, low_noise], e.g. 4 2. "
-        "Overrides --cache_warmup via a per-transformer ParamsModifier.",
+        default=[6, 3],
+        help="Per-transformer warmup steps for Wan2.2-A14B [high_noise, low_noise]. "
+        "Default [6, 3] is the validated best-speed/good-quality config (~2.06x denoise, threshold 0.15). "
+        "Overrides --cache_warmup via a per-transformer ParamsModifier; pass a single value for single-transformer models.",
     )
     parser.add_argument(
         "--cache_threshold_per_transformer",

--- a/examples/stable-diffusion/wan_t2v_quantization.py
+++ b/examples/stable-diffusion/wan_t2v_quantization.py
@@ -175,6 +175,57 @@ def main():
 
     parser.add_argument("--seed", type=int, default=42, help="Random seed for initialization.")
 
+    # cache_dit (DBCache) block-caching arguments
+    parser.add_argument(
+        "--use_cache_dit",
+        action="store_true",
+        help="Enable cache_dit (DBCache) block-level caching to accelerate inference.",
+    )
+    parser.add_argument(
+        "--cache_threshold",
+        type=float,
+        default=0.15,
+        help="cache_dit residual_diff_threshold (higher caches more: faster, lower fidelity).",
+    )
+    parser.add_argument(
+        "--cache_warmup",
+        type=int,
+        default=8,
+        help="cache_dit global max_warmup_steps (initial steps always computed).",
+    )
+    parser.add_argument(
+        "--cache_fn_blocks",
+        type=int,
+        default=1,
+        help="cache_dit Fn_compute_blocks (leading transformer blocks always computed).",
+    )
+    parser.add_argument(
+        "--cache_warmup_per_transformer",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Per-transformer warmup steps for Wan2.2 [high_noise, low_noise], e.g. 4 2. "
+        "Overrides --cache_warmup via a per-transformer ParamsModifier.",
+    )
+    parser.add_argument(
+        "--cache_threshold_per_transformer",
+        type=float,
+        nargs="+",
+        default=None,
+        help="Per-transformer thresholds aligned to --cache_warmup_per_transformer, e.g. 0.24 0.24.",
+    )
+    parser.add_argument(
+        "--no_taylorseer",
+        action="store_true",
+        help="Disable the cache_dit TaylorSeer calibrator (enabled by default).",
+    )
+    parser.add_argument(
+        "--taylorseer_order",
+        type=int,
+        default=1,
+        help="cache_dit TaylorSeer expansion order.",
+    )
+
     # HPU-specific arguments
     parser.add_argument("--use_habana", action="store_true", help="Use HPU.")
     parser.add_argument(
@@ -219,7 +270,8 @@ def main():
 
     kwargs = {
         "use_habana": args.use_habana,
-        "use_hpu_graphs": args.use_hpu_graphs,
+        # cache_dit hooks eager block forwards and is incompatible with HPU graphs; force eager when caching.
+        "use_hpu_graphs": False if args.use_cache_dit else args.use_hpu_graphs,
         "gaudi_config": gaudi_config,
     }
     if args.dtype == "bf16":
@@ -254,6 +306,19 @@ def main():
                 pipeline.transformer_2 = prepare(pipeline.transformer_2, config_2)
             elif config_2.quantize:
                 pipeline.transformer_2 = convert(pipeline.transformer_2, config_2)
+
+    # Enable cache_dit (DBCache) block caching after any FP8 convert. The two acceleration axes
+    # (FP8 quant + cache_dit) are orthogonal and compound.
+    if args.use_cache_dit:
+        pipeline.enable_cache_dit(
+            residual_diff_threshold=args.cache_threshold,
+            max_warmup_steps=args.cache_warmup,
+            Fn_compute_blocks=args.cache_fn_blocks,
+            use_taylorseer=not args.no_taylorseer,
+            taylorseer_order=args.taylorseer_order,
+            warmup_steps_per_transformer=args.cache_warmup_per_transformer,
+            thresholds_per_transformer=args.cache_threshold_per_transformer,
+        )
 
     set_seed(args.seed)
 

--- a/examples/stable-diffusion/wan_t2v_quantization.py
+++ b/examples/stable-diffusion/wan_t2v_quantization.py
@@ -203,9 +203,10 @@ def main():
         "--cache_warmup_per_transformer",
         type=int,
         nargs="+",
-        default=None,
-        help="Per-transformer warmup steps for Wan2.2 [high_noise, low_noise], e.g. 4 2. "
-        "Overrides --cache_warmup via a per-transformer ParamsModifier.",
+        default=[6, 3],
+        help="Per-transformer warmup steps for Wan2.2-A14B [high_noise, low_noise]. "
+        "Default [6, 3] is the validated best-speed/good-quality config (~2.06x denoise, threshold 0.15). "
+        "Overrides --cache_warmup via a per-transformer ParamsModifier; pass a single value for single-transformer models.",
     )
     parser.add_argument(
         "--cache_threshold_per_transformer",

--- a/optimum/habana/diffusers/pipelines/wan/pipeline_wan.py
+++ b/optimum/habana/diffusers/pipelines/wan/pipeline_wan.py
@@ -152,6 +152,121 @@ class GaudiWanPipeline(GaudiDiffusionPipeline, WanPipeline):
             if self.transformer_2 is not None:
                 self.transformer_2 = wrap_in_hpu_graph(transformer_2)
 
+    def enable_cache_dit(
+        self,
+        residual_diff_threshold: float = 0.24,
+        max_warmup_steps: int = 8,
+        Fn_compute_blocks: int = 1,
+        Bn_compute_blocks: int = 0,
+        max_continuous_cached_steps: int = 3,
+        use_taylorseer: bool = True,
+        taylorseer_order: int = 1,
+        warmup_steps_per_transformer: Optional[List[int]] = None,
+        thresholds_per_transformer: Optional[List[float]] = None,
+    ):
+        r"""
+        Enable cache_dit (DBCache) block-level caching on the Wan transformer(s) to accelerate
+        inference. Stacks on top of bf16 or FP8 — call this AFTER any FP8 convert, and before
+        generation. Requires eager mode (`use_hpu_graphs=False`): cache_dit hooks the eager
+        block forwards and is incompatible with HPU graphs.
+
+        Wan2.2-A14B exposes two transformers (high-noise `transformer`, low-noise
+        `transformer_2`); both are registered as a dual `BlockAdapter`. Per-transformer warmup
+        and threshold are supplied via `warmup_steps_per_transformer` / `thresholds_per_transformer`
+        (each a list aligned to the present transformers, e.g. `[4, 2]` for [high-noise, low-noise]).
+        When `warmup_steps_per_transformer` is omitted, the global `max_warmup_steps` /
+        `residual_diff_threshold` apply to every transformer.
+
+        Args:
+            residual_diff_threshold (`float`, defaults to `0.24`):
+                DBCache residual-difference threshold; higher caches more (faster, lower fidelity).
+            max_warmup_steps (`int`, defaults to `8`):
+                Number of initial steps always computed (never cached), applied globally.
+            Fn_compute_blocks (`int`, defaults to `1`):
+                Number of leading transformer blocks always computed each step.
+            Bn_compute_blocks (`int`, defaults to `0`):
+                Number of trailing transformer blocks always computed each step.
+            max_continuous_cached_steps (`int`, defaults to `3`):
+                Cap on consecutive cached steps before forcing a full recompute.
+            use_taylorseer (`bool`, defaults to `True`):
+                Enable the TaylorSeer calibrator to approximate cached residuals.
+            taylorseer_order (`int`, defaults to `1`):
+                TaylorSeer expansion order.
+            warmup_steps_per_transformer (`List[int]`, *optional*):
+                Per-transformer warmup steps, aligned to the present transformers (e.g. `[4, 2]`).
+                Enables a per-transformer `ParamsModifier` override.
+            thresholds_per_transformer (`List[float]`, *optional*):
+                Per-transformer thresholds, aligned to `warmup_steps_per_transformer`. Falls back
+                to `residual_diff_threshold` for every transformer when omitted.
+        """
+        import cache_dit
+        from cache_dit import DBCacheConfig
+
+        transformers = [t for t in (self.transformer, self.transformer_2) if t is not None]
+        if not transformers:
+            raise ValueError("enable_cache_dit() requires at least one transformer on the pipeline.")
+        adapter = cache_dit.BlockAdapter(
+            pipe=self,
+            transformer=transformers,
+            blocks=[t.blocks for t in transformers],
+            forward_pattern=[cache_dit.Pattern_2] * len(transformers),
+            check_forward_pattern=True,
+            has_separate_cfg=True,
+        )
+
+        calibrator_config = None
+        if use_taylorseer:
+            calibrator_config = cache_dit.TaylorSeerCalibratorConfig(taylorseer_order=taylorseer_order)
+
+        params_modifiers = None
+        if warmup_steps_per_transformer is not None:
+            from cache_dit import ParamsModifier
+
+            if thresholds_per_transformer is None:
+                thresholds_per_transformer = [residual_diff_threshold] * len(warmup_steps_per_transformer)
+            if len(thresholds_per_transformer) != len(warmup_steps_per_transformer):
+                raise ValueError(
+                    "thresholds_per_transformer and warmup_steps_per_transformer must have the same length."
+                )
+            params_modifiers = [
+                ParamsModifier(
+                    cache_config=DBCacheConfig(
+                        Fn_compute_blocks=Fn_compute_blocks,
+                        Bn_compute_blocks=Bn_compute_blocks,
+                        max_warmup_steps=warmup,
+                        max_continuous_cached_steps=max_continuous_cached_steps,
+                        residual_diff_threshold=threshold,
+                    )
+                )
+                for warmup, threshold in zip(warmup_steps_per_transformer, thresholds_per_transformer)
+            ]
+
+        cache_dit.enable_cache(
+            adapter,
+            cache_config=DBCacheConfig(
+                Fn_compute_blocks=Fn_compute_blocks,
+                Bn_compute_blocks=Bn_compute_blocks,
+                max_warmup_steps=max_warmup_steps,
+                max_continuous_cached_steps=max_continuous_cached_steps,
+                residual_diff_threshold=residual_diff_threshold,
+            ),
+            calibrator_config=calibrator_config,
+            params_modifiers=params_modifiers,
+        )
+        logger.info(
+            "cache_dit enabled: threshold=%s, max_warmup_steps=%s, Fn=%s, Bn=%s, "
+            "per_transformer_warmup=%s, per_transformer_threshold=%s, taylorseer=%s(order=%s)",
+            residual_diff_threshold,
+            max_warmup_steps,
+            Fn_compute_blocks,
+            Bn_compute_blocks,
+            warmup_steps_per_transformer,
+            thresholds_per_transformer,
+            use_taylorseer,
+            taylorseer_order,
+        )
+        return self
+
     def prepare_latents(
         self,
         batch_size: int,

--- a/optimum/habana/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/optimum/habana/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -169,6 +169,121 @@ class GaudiWanImageToVideoPipeline(GaudiDiffusionPipeline, WanImageToVideoPipeli
             if self.transformer_2 is not None:
                 self.transformer_2 = wrap_in_hpu_graph(transformer_2)
 
+    def enable_cache_dit(
+        self,
+        residual_diff_threshold: float = 0.24,
+        max_warmup_steps: int = 8,
+        Fn_compute_blocks: int = 1,
+        Bn_compute_blocks: int = 0,
+        max_continuous_cached_steps: int = 3,
+        use_taylorseer: bool = True,
+        taylorseer_order: int = 1,
+        warmup_steps_per_transformer: Optional[List[int]] = None,
+        thresholds_per_transformer: Optional[List[float]] = None,
+    ):
+        r"""
+        Enable cache_dit (DBCache) block-level caching on the Wan transformer(s) to accelerate
+        inference. Stacks on top of bf16 or FP8 — call this AFTER any FP8 convert, and before
+        generation. Requires eager mode (`use_hpu_graphs=False`): cache_dit hooks the eager
+        block forwards and is incompatible with HPU graphs.
+
+        Wan2.2-A14B exposes two transformers (high-noise `transformer`, low-noise
+        `transformer_2`); both are registered as a dual `BlockAdapter`. Per-transformer warmup
+        and threshold are supplied via `warmup_steps_per_transformer` / `thresholds_per_transformer`
+        (each a list aligned to the present transformers, e.g. `[4, 2]` for [high-noise, low-noise]).
+        When `warmup_steps_per_transformer` is omitted, the global `max_warmup_steps` /
+        `residual_diff_threshold` apply to every transformer.
+
+        Args:
+            residual_diff_threshold (`float`, defaults to `0.24`):
+                DBCache residual-difference threshold; higher caches more (faster, lower fidelity).
+            max_warmup_steps (`int`, defaults to `8`):
+                Number of initial steps always computed (never cached), applied globally.
+            Fn_compute_blocks (`int`, defaults to `1`):
+                Number of leading transformer blocks always computed each step.
+            Bn_compute_blocks (`int`, defaults to `0`):
+                Number of trailing transformer blocks always computed each step.
+            max_continuous_cached_steps (`int`, defaults to `3`):
+                Cap on consecutive cached steps before forcing a full recompute.
+            use_taylorseer (`bool`, defaults to `True`):
+                Enable the TaylorSeer calibrator to approximate cached residuals.
+            taylorseer_order (`int`, defaults to `1`):
+                TaylorSeer expansion order.
+            warmup_steps_per_transformer (`List[int]`, *optional*):
+                Per-transformer warmup steps, aligned to the present transformers (e.g. `[4, 2]`).
+                Enables a per-transformer `ParamsModifier` override.
+            thresholds_per_transformer (`List[float]`, *optional*):
+                Per-transformer thresholds, aligned to `warmup_steps_per_transformer`. Falls back
+                to `residual_diff_threshold` for every transformer when omitted.
+        """
+        import cache_dit
+        from cache_dit import DBCacheConfig
+
+        transformers = [t for t in (self.transformer, self.transformer_2) if t is not None]
+        if not transformers:
+            raise ValueError("enable_cache_dit() requires at least one transformer on the pipeline.")
+        adapter = cache_dit.BlockAdapter(
+            pipe=self,
+            transformer=transformers,
+            blocks=[t.blocks for t in transformers],
+            forward_pattern=[cache_dit.Pattern_2] * len(transformers),
+            check_forward_pattern=True,
+            has_separate_cfg=True,
+        )
+
+        calibrator_config = None
+        if use_taylorseer:
+            calibrator_config = cache_dit.TaylorSeerCalibratorConfig(taylorseer_order=taylorseer_order)
+
+        params_modifiers = None
+        if warmup_steps_per_transformer is not None:
+            from cache_dit import ParamsModifier
+
+            if thresholds_per_transformer is None:
+                thresholds_per_transformer = [residual_diff_threshold] * len(warmup_steps_per_transformer)
+            if len(thresholds_per_transformer) != len(warmup_steps_per_transformer):
+                raise ValueError(
+                    "thresholds_per_transformer and warmup_steps_per_transformer must have the same length."
+                )
+            params_modifiers = [
+                ParamsModifier(
+                    cache_config=DBCacheConfig(
+                        Fn_compute_blocks=Fn_compute_blocks,
+                        Bn_compute_blocks=Bn_compute_blocks,
+                        max_warmup_steps=warmup,
+                        max_continuous_cached_steps=max_continuous_cached_steps,
+                        residual_diff_threshold=threshold,
+                    )
+                )
+                for warmup, threshold in zip(warmup_steps_per_transformer, thresholds_per_transformer)
+            ]
+
+        cache_dit.enable_cache(
+            adapter,
+            cache_config=DBCacheConfig(
+                Fn_compute_blocks=Fn_compute_blocks,
+                Bn_compute_blocks=Bn_compute_blocks,
+                max_warmup_steps=max_warmup_steps,
+                max_continuous_cached_steps=max_continuous_cached_steps,
+                residual_diff_threshold=residual_diff_threshold,
+            ),
+            calibrator_config=calibrator_config,
+            params_modifiers=params_modifiers,
+        )
+        logger.info(
+            "cache_dit enabled: threshold=%s, max_warmup_steps=%s, Fn=%s, Bn=%s, "
+            "per_transformer_warmup=%s, per_transformer_threshold=%s, taylorseer=%s(order=%s)",
+            residual_diff_threshold,
+            max_warmup_steps,
+            Fn_compute_blocks,
+            Bn_compute_blocks,
+            warmup_steps_per_transformer,
+            thresholds_per_transformer,
+            use_taylorseer,
+            taylorseer_order,
+        )
+        return self
+
     def prepare_latents(
         self,
         image: PipelineImageInput,


### PR DESCRIPTION
Adds first-class [cache_dit](https://github.com/vipshop/cache-dit) (DBCache) acceleration to the
Gaudi Wan pipeline. cache_dit skips redundant transformer-block compute between diffusion steps
(residual-diff threshold), an acceleration axis orthogonal to FP8 — the two compound.

The integration is a single additive method GaudiWanPipeline.enable_cache_dit(...) that wires the
two Wan2.2 transformers (high-noise transformer + low-noise transformer_2) into a dual
BlockAdapter, plus matching --use_cache_dit / --cache_* flags on the canonical T2V example
(the run_wan_t2v_demo.sh flow). No existing code path changes — output is bit-for-bit unchanged
when caching is off.