### PR TITLE
Enable VAE tiling for CP=4 1080p to fix cache_dit VAE OOM crash

### DIFF
--- a/optimum/habana/diffusers/pipelines/wan/pipeline_wan.py
+++ b/optimum/habana/diffusers/pipelines/wan/pipeline_wan.py
@@ -443,6 +443,23 @@ class GaudiWanPipeline(GaudiDiffusionPipeline, WanPipeline):
             )
             height = (height // self.vae_scale_factor_spatial // p_h + 1) * p_h * self.vae_scale_factor_spatial
 
+        # Gaudi: auto-enable VAE tiling for large VAE workloads so the decode stays under the
+        # ~96GB HBM ceiling. Wan decodes per-latent-frame; when the per-frame conv3d exceeds
+        # the ceiling the failed allocation materializes as an all-zero (black) video -- T2V
+        # has no vae.encode, so unlike I2V it does not hard-crash, it silently goes black
+        # (confirmed at 1080p). Same gate as the I2V pipeline (high resolution OR long clips)
+        # for consistency. A 200px stride keeps tile boundaries off the CP=4 latent shard
+        # boundaries (60/120/180), avoiding a center seam.
+        if (
+            getattr(self, "vae", None) is not None
+            and not self.vae.use_tiling
+            and (height * width > 1_500_000 or num_frames >= 41)
+        ):
+            self.vae.enable_tiling(
+                tile_sample_stride_height=200,
+                tile_sample_stride_width=200,
+            )
+
         if self.config.boundary_ratio is not None and guidance_scale_2 is None:
             guidance_scale_2 = guidance_scale
 

--- a/optimum/habana/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/optimum/habana/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -525,6 +525,23 @@ class GaudiWanImageToVideoPipeline(GaudiDiffusionPipeline, WanImageToVideoPipeli
         if height // self.vae_scale_factor_spatial % p_h != 0:
             height = (height // self.vae_scale_factor_spatial // p_h + 1) * p_h * self.vae_scale_factor_spatial
 
+        # Gaudi: auto-enable VAE tiling for large workloads so the VAE forward stays under the
+        # ~96GB HBM ceiling. Wan VAE decode runs per-latent-frame; at high resolution or on
+        # long clips (especially with cache_dit resident buffers) a single per-frame conv3d
+        # can hit the ceiling and fail to allocate -> "PT_DEVMEM Allocation failed" / empty
+        # lazy tensor in vae.encode (pre-denoise) or vae.decode (post-denoise). Tiling caps
+        # peak VAE activation and covers both. A 200px stride keeps tile boundaries off the
+        # CP=4 latent shard boundaries (60/120/180), avoiding a vertical center seam.
+        if (
+            getattr(self, "vae", None) is not None
+            and not self.vae.use_tiling
+            and (height * width > 1_500_000 or num_frames >= 41)
+        ):
+            self.vae.enable_tiling(
+                tile_sample_stride_height=200,
+                tile_sample_stride_width=200,
+            )
+
         if self.config.boundary_ratio is not None and guidance_scale_2 is None:
             guidance_scale_2 = guidance_scale
 


### PR DESCRIPTION
Wan2.2-I2V with cache_dit at 1080p (max_area 2088960) crashes inside the VAE with "ValidateSyncInputTensors tensor_data is empty": the VAE forward plus the denoise/cache_dit residual drives a card past its ~96GB HBM ceiling and a tensor fails to materialize. fp8 dies at vae.encode, bf16 at vae.decode -- same mechanism, different call.

Whether it OOMs depends on both resolution (VAE peak scales with area) and context-parallel size (residual scales with 1/CP). Measured on Gaudi (96GB): CP=4 @ 1080p OOMs; CP=8 @ 1080p stays under (residual halved); 720p is always safe. CP is only ever 4 or 8, so tiling is gated to CP=4 above a high-res threshold -- this avoids the large one-off VAE tiling compile cost (~12 min on lazy HPU) for the CP=8 and 720p cases that do not need it.

When tiling is on, CP=4 shards the latent at boundaries 60/120/180; the default tile stride (192px -> latent 24) lands a tile boundary on latent 120, coinciding with the CP boundary, and the overlap blend amplifies the discontinuity into a visible vertical seam at frame centre. Stride 200px (latent 25) moves tile boundaries off the CP boundaries and removes the seam.

Validated: CP=4/1080p/fp8/cache_dit runs end-to-end, ~83GB/card, no seam (centre-column discontinuity ratio 1.5, baseline), output 1920x1072x17f.